### PR TITLE
Fix support for VLAN tagged frames received on RAW sockets.

### DIFF
--- a/nio_linux_raw.h
+++ b/nio_linux_raw.h
@@ -26,8 +26,8 @@
 #define VLAN_HEADER_LEN 4
 
 typedef struct {
-    uint16_t vlan_tp_id;
-    uint16_t vlan_tci;
+    u_int16_t vlan_tp_id;
+    u_int16_t vlan_tci;
 } vlan_tag_t;
 
 nio_t *create_nio_linux_raw(char *dev_name);


### PR DESCRIPTION
Tested on Debian Stretch (Kernel 4.8.7) and OS X 10.11.6.
On OS X it worked before, I verified that the changes don't break it.