### PR TITLE
Update nio_udp.c

### DIFF
--- a/nio_udp.c
+++ b/nio_udp.c
@@ -25,6 +25,7 @@
 #include <arpa/inet.h>
 #include <limits.h>
 #include <netdb.h>
+#include <netinet/in.h>
 
 #include "ubridge.h"
 #include "nio_udp.h"


### PR DESCRIPTION
Adding this part fixes FreeBSD support. Only tested on FreeBSD.