### PR TITLE
Do not require an IPv4 address to use ethernet devices

### DIFF
--- a/nio.h
+++ b/nio.h
@@ -52,8 +52,6 @@ typedef struct {
 
 typedef struct {
     pcap_t *pcap_dev;
-	bpf_u_int32 net;
-	bpf_u_int32 mask;
 } nio_ethernet_t;
 
 typedef struct {

--- a/nio_ethernet.c
+++ b/nio_ethernet.c
@@ -114,7 +114,6 @@ static ssize_t nio_ethernet_recv(nio_ethernet_t *nio_ethernet, void *pkt, size_t
 /* Create a new NIO Ethernet (using PCAP) */
 nio_t *create_nio_ethernet(char *dev_name)
 {
-   char pcap_errbuf[PCAP_ERRBUF_SIZE];
    nio_ethernet_t *nio_ethernet;
    nio_t *nio;
 
@@ -124,12 +123,6 @@ nio_t *create_nio_ethernet(char *dev_name)
    nio_ethernet = &nio->u.nio_ethernet;
 
    if (!(nio_ethernet->pcap_dev = nio_ethernet_open(dev_name))) {
-      free_nio(nio);
-      return NULL;
-   }
-
-   if (pcap_lookupnet(dev_name, &nio_ethernet->net, &nio_ethernet->mask, pcap_errbuf) < 0) {
-      fprintf(stderr, "Cannot get netmask for device '%s': %s\n", dev_name, pcap_errbuf);
       free_nio(nio);
       return NULL;
    }

--- a/pcap_filter.c
+++ b/pcap_filter.c
@@ -31,7 +31,7 @@ int set_pcap_filter(nio_ethernet_t *nio_ethernet, const char *filter)
 {
      struct bpf_program fp;
 
-	 if (pcap_compile(nio_ethernet->pcap_dev, &fp, filter, 1, nio_ethernet->mask) < 0) {
+	 if (pcap_compile(nio_ethernet->pcap_dev, &fp, filter, 1, PCAP_NETMASK_UNKNOWN) < 0) {
 	    fprintf(stderr, "Cannot compile filter '%s': %s\n", filter, pcap_geterr(nio_ethernet->pcap_dev));
 		return (-1);
 	 }


### PR DESCRIPTION
`pcap_lookupnet()` succeeds only if we have an IPv4 address on the
interface. This call was added to get a netmask that would be in turn
used by `pcap_compile()`. However, this netmask is only needed to test
for IPv4 broadcast addresses. This is a niche use. Just do not provide a
netmask. Being able to "bridge" an interface without an IP address is
more important. `tcpdump` doesn't provide a netmask to `pcap_compile()`
either.