### PR TITLE
Make ubridge packager friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,6 @@ install : $(NAME)
 else
 install : $(NAME)
 	chmod +x $(NAME)
-	cp $(NAME) $(BINDIR)
+	cp -p $(NAME) $(BINDIR)
 	setcap cap_net_admin,cap_net_raw=ep $(BINDIR)/$(NAME)
 endif

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ SRC     =   src/ubridge.c               \
             src/nio_unix.c              \
             src/nio_ethernet.c          \
             src/nio_tap.c               \
-            src/iniparser/iniparser.c   \
-            src/iniparser/dictionary.c  \
             src/parse.c                 \
             src/packet_filter.c         \
             src/pcap_capture.c          \
@@ -36,6 +34,7 @@ SRC     =   src/ubridge.c               \
             src/hypervisor.c            \
             src/hypervisor_parser.c     \
             src/hypervisor_bridge.c
+
 
 OBJ     =   $(SRC:.c=.o)
 
@@ -64,6 +63,13 @@ ifeq ($(shell uname), Linux)
            src/hypervisor_iol_bridge.c     \
            src/hypervisor_brctl.c   \
            src/netlink/nl.c
+endif
+
+ifeq ($(SYSTEM_INIPARSER),1)
+    CFLAGS += -DUSE_SYSTEM_INIPARSER
+else
+    SRC += src/iniparser/iniparser.c   \
+	   src/iniparser/dictionary.c
 endif
 
 ##############################

--- a/src/parse.h
+++ b/src/parse.h
@@ -22,7 +22,12 @@
 #define PARSE_H_
 
 #include "ubridge.h"
+
+#ifdef USE_SYSTEM_INIPARSER
+#include <iniparser.h>
+#else
 #include "iniparser/iniparser.h"
+#endif
 
 #define MAX_KEY_SIZE   256
 


### PR DESCRIPTION
This PR is to make ubridge packager friendly:

- Preserve timestamps
- Provide an option to not use the bundled iniparse lib and use system provided one instead.

PS. I'm packaging this as part of Fedora GNS3 packages update