### PR TITLE
Fix compilation (missing ioctl.h) on FreeBSD

### DIFF
--- a/src/nio_ethernet.c
+++ b/src/nio_ethernet.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <sys/ioctl.h>
 #include <pthread.h>
 
 #include "ubridge.h"


### PR DESCRIPTION
Compilation failed on FreeBSD (it uses clang) because ioctl.h is missing.