### PR TITLE
Add section on FreeBSD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,18 @@ In the source directory:
     make
     sudo make install
     
+FreeBSD
+################################################
+
+In the source directory:
+
+.. code:: bash
+    gmake
+    sudo make install
+    
+Be sure to modify gns_server.conf to point to /usr/local/bin/ubridge.
+    
+    
 Windows
 ################################################
 


### PR DESCRIPTION
Add section on how to get it to compile on FreeBSD. FreeBSD uses a different  Makefile format to Linux and this will compile only with gmake.