### PR TITLE
Respect CFLAGS/LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ OBJ     =   $(SRC:.c=.o)
 
 CC      ?=   gcc
 
-CFLAGS  =   -O3 -Wall
+CFLAGS  +=   -Wall
 
 BINDIR  =   /usr/local/bin
 
@@ -76,7 +76,7 @@ endif
 ##############################
 
 $(NAME)	: $(OBJ)
-	$(CC) -o $(NAME) $(OBJ) $(LIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $(NAME) $(OBJ) $(LIBS)
 
 .PHONY: clean
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
 
 build_script:
     - '%CYG_ROOT%/bin/bash -lc "ls $APPVEYOR_BUILD_FOLDER'
-    - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make CFLAGS=\"-O3 -Wall -lpthread -lpcap -IWpdPack\\Include\"'
+    - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make CFLAGS=\"-O3 -Wall -IWpdPack\\Include\"'
 
 
 artifacts:


### PR DESCRIPTION
Dear ubridge developers,

While preparing an official ubridge package [1] for source-based Gentoo GNU/Linux distribution, I noticed that Makefile doesn't respect end users' compiler preferences, particularly CFLAGS and LDFLAGS. The patch solves the issue. Many thanks in advance!

[1] https://github.com/gentoo/gentoo/commit/39abda0e971135151278cef6aad8acf83d02b881