### PR TITLE
Correct runtime issue for ARM64

### DIFF
--- a/src/ubridge.c
+++ b/src/ubridge.c
@@ -334,7 +334,7 @@ int main(int argc, char **argv)
 {
   int hypervisor_tcp_port = 0;
   char *hypervisor_ip_address = NULL;
-  char opt;
+  int opt;
   char *index;
   size_t len;
 


### PR DESCRIPTION
The getopt return is an int, and with the current code on ARM64 is being interpreted as a 255 given the opt is a char, causing to go into the default switch statement (and aborting the program silently).