### PR TITLE
Prevent perror() modifying errno

### DIFF
--- a/src/ubridge.h
+++ b/src/ubridge.h
@@ -50,6 +50,9 @@
 #define handle_error_en(en, msg) \
         do { errno = en; perror(msg); exit(EXIT_FAILURE); } while (0)
 
+#define perror(msg) \
+        do { int en = errno; perror(msg); errno = en; } while (0)
+
 typedef struct {
     pcap_t *fd;
     pcap_dumper_t *dumper;


### PR DESCRIPTION
Normally perror() has the unwanted side effect, that it may modify the errno variable. This PR makes perror() safe.

Commit https://github.com/GNS3/ubridge/commit/95cdb49cec4237d6349cf38b2b3d5e58d4ff465d can be reverted now.