### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Open the Cygwin terminal:
 
 .. code:: bash
 
-    git clone git://github.com/GNS3/ubridge.git
+    git clone https://github.com/GNS3/ubridge.git
     cd ubridge
     make
 


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported.
https://github.blog/2021-09-01-improving-git-protocol-security-github/