### PR TITLE
Reset bridge_list after freeing resources

### DIFF
--- a/src/ubridge.c
+++ b/src/ubridge.c
@@ -319,6 +319,7 @@ static void ubridge(char *hypervisor_ip_address, int hypervisor_tcp_port)
          sigwait(&sigset, &sig);
 
          free_bridges(bridge_list);
+         bridge_list = NULL;
          if (sig == SIGTERM || sig == SIGINT)
             break;
          printf("Reloading configuration\n");


### PR DESCRIPTION
After resources have been freed, bridge_list does not point to valid data any longer and hence has to be reset.

An alternative implementation would change the signature of free_bridges(bridge_t *bridge) to free_bridges(bridge_t **bridge) (analogously to add_bridge) and reset the parameter by side effect.