### PR TITLE
Fix memory corruption and SIGSEGV crashes in IOL bridge operations

### DIFF
--- a/src/hypervisor_iol_bridge.c
+++ b/src/hypervisor_iol_bridge.c
@@ -688,6 +688,8 @@ static int create_iol_port_entry(hypervisor_conn_t *conn, iol_bridge_t *bridge, 
    }
 
    iol_nio->destination_nio = nio;
+   iol_nio->capture = NULL;
+   iol_nio->packet_filters = NULL;
    /* start the NIO thread if the bridge is already running */
    if (bridge->running) {
       s = pthread_create(&(iol_nio->tid), NULL, &iol_nio_listener, iol_nio);
@@ -766,6 +768,8 @@ static int cmd_delete_nio_udp(hypervisor_conn_t *conn, int argc, char *argv[])
    }
 
    iol_nio->destination_nio = NULL;
+   iol_nio->capture = NULL;
+   iol_nio->packet_filters = NULL;
    hypervisor_send_reply(conn, HSC_INFO_OK,1, "NIO UDP deleted from IOL bridge '%s'", argv[0]);
    return (0);
 }

--- a/src/ubridge.c
+++ b/src/ubridge.c
@@ -165,10 +165,12 @@ static void free_bridges(bridge_t *bridge)
   while (bridge != NULL) {
     if (bridge->name)
        free(bridge->name);
-    pthread_cancel(bridge->source_tid);
-    pthread_join(bridge->source_tid, NULL);
-    pthread_cancel(bridge->destination_tid);
-    pthread_join(bridge->destination_tid, NULL);
+    if (bridge->running) {
+       pthread_cancel(bridge->source_tid);
+       pthread_join(bridge->source_tid, NULL);
+       pthread_cancel(bridge->destination_tid);
+       pthread_join(bridge->destination_tid, NULL);
+    }
     free_nio(bridge->source_nio);
     free_nio(bridge->destination_nio);
     free_pcap_capture(bridge->capture);
@@ -194,12 +196,16 @@ static void free_iol_bridges(iol_bridge_t *bridge)
     if ((unlock_unix_socket(bridge->sock_lock, bridge->bridge_sockaddr.sun_path)) == -1)
        fprintf(stderr, "failed to unlock %s\n", bridge->bridge_sockaddr.sun_path);
 
-    pthread_cancel(bridge->bridge_tid);
-    pthread_join(bridge->bridge_tid, NULL);
+    if (bridge->running) {
+       pthread_cancel(bridge->bridge_tid);
+       pthread_join(bridge->bridge_tid, NULL);
+    }
     for (i = 0; i < MAX_PORTS; i++) {
         if (bridge->port_table[i].destination_nio != NULL) {
-           pthread_cancel(bridge->port_table[i].tid);
-           pthread_join(bridge->port_table[i].tid, NULL);
+           if (bridge->running) {
+              pthread_cancel(bridge->port_table[i].tid);
+              pthread_join(bridge->port_table[i].tid, NULL);
+           }
            free_pcap_capture(bridge->port_table[i].capture);
            free_packet_filters(bridge->port_table[i].packet_filters);
            free_nio(bridge->port_table[i].destination_nio);


### PR DESCRIPTION
Fix two memory safety bugs affecting IOL bridge and standard bridge operations.

### Commit 1: Fix double-free bug in IOL bridge packet_filters management

This commit fixes a critical double-free bug that occurs during link reset operations in the IOL bridge implementation.

**Root Cause:** When deleting an NIO UDP connection, the code correctly freed the packet_filters and capture structures but failed to set the corresponding pointers to NULL. This created dangling pointers that could be accessed later, causing double-free crashes.

**Problem Flow:**
1. `delete_nio_udp()` calls `free_packet_filters()` but doesn't set `packet_filters = NULL`
2. `create_iol_port_entry()` skips cleanup because `destination_nio == NULL`
3. New threads access dangling `packet_filters` pointer
4. `reset_packet_filters()` calls `free_packet_filters()` on already-freed memory
5. Result: `free(): invalid pointer` crash

**Fix:** Added `iol_nio->capture = NULL` and `iol_nio->packet_filters = NULL` after freeing in both `delete_nio_udp()` and `create_iol_port_entry()`.

### Commit 2: Fix SIGSEGV in free_bridges and free_iol_bridges by checking running state

This commit fixes a SIGSEGV crash that occurs when closing topologies involving Docker and IOL connections.

**Root Cause:** The `free_bridges()` and `free_iol_bridges()` functions unconditionally called `pthread_cancel()` on thread handles without checking if the bridges were actually running. This caused SIGSEGV when bridges were created but never started (uninitialized `pthread_t`), or when thread handles were in an inconsistent state during cleanup.

**Fix:** Added `bridge->running` checks before calling `pthread_cancel()` in both `free_bridges()` and `free_iol_bridges()`, ensuring `pthread_cancel()` is only called on valid, running thread handles.

Both fixes are minimal and focused on the specific memory safety issues without introducing behavioral changes to the normal bridge operations.