### PR TITLE
Fix brctl netlink error-path bugs: dump truncation, realloc silent-success, fd leak

### DIFF
--- a/doc/brctl.md
+++ b/doc/brctl.md
@@ -109,8 +109,9 @@ already be enslaved to the bridge; otherwise `-EINVAL`.
   Mixing them up makes the kernel silently ignore the change.
 - **dump parsing** — `br_dump_addresses` walks every `nlmsg`
   packed into a `recvmsg()` datagram via `NLMSG_OK`/`NLMSG_NEXT` (a datagram
-  may carry several coalesced records). `NLMSG_ERROR` is treated as a real
-  failure, never as end-of-dump.
+  may carry several coalesced records). `NLMSG_ERROR` and any `recv` error
+  (e.g. `-EMSGSIZE` when a datagram overflows the receive buffer) are treated
+  as a real failure, never as end-of-dump.
 - **`<bridge>` scoping** — `delif` and the port-parameter commands query the
   port's current master (`IFLA_MASTER` via `RTM_GETLINK`) and reject (`-EINVAL`)
   operations on a port not enslaved to the specified bridge, matching classic
@@ -126,6 +127,9 @@ already be enslaved to the bridge; otherwise `-EINVAL`.
 | Port params missing `ifi_family=AF_BRIDGE` and `NLA_F_NESTED` on `IFLA_PROTINFO` | Kernel silently ignored port attribute changes | Set `AF_BRIDGE`; set `NLA_F_NESTED` on the nested `IFLA_PROTINFO` header |
 | `parse_cidr` truncated overlong input with `strncpy` | Invalid overlong CIDR could look valid after truncation | Reject `strlen(cidr) >= sizeof(buf)` up front |
 | `setup` created the bridge before validating the CIDR | Invalid CIDR left a half-created bridge | Validate CIDR first; also roll back the bridge if `addip` fails |
+| Dump `recv` error (e.g. `-EMSGSIZE` when a datagram overflows the buffer) treated as end-of-dump | `br_get_address` silently returned a truncated address list as complete → `show` printed a wrong/missing IP | Treat `netlink_rcv < 0` as failure (`ret = -1`); only `r == 0` / `NLMSG_DONE` ends the dump |
+| `realloc` failure in `br_dump_addresses` jumped to the success path | Partial address list returned as a complete dump under memory pressure | `ret = -1; goto out` on realloc failure |
+| `netlink_open` returned `-errno` without closing the socket after `setsockopt` / `bind` / `getsockname` failed | fd leak on (rare) open-time failure paths | `goto err` closes the fd and preserves the original errno |
 
 ## Testing
 

--- a/src/hypervisor_brctl.c
+++ b/src/hypervisor_brctl.c
@@ -182,7 +182,7 @@ static int br_enslave_if(const char *bridge, const char *port)
     memset(ifi, 0, sizeof(*ifi));
     ifi->ifi_family = AF_UNSPEC;
     ifi->ifi_index = port_ifindex;
-    ifi->ifi_change |= IFF_UP;
+    ifi->ifi_change = IFF_UP;
     ifi->ifi_flags |= IFF_UP;
 
     msg->nlmsghdr.nlmsg_type = RTM_SETLINK;
@@ -333,6 +333,19 @@ static int br_release_if(const char *bridge, const char *port)
 }
 
 /*
+ * Convert a network-order IPv4 netmask into a prefix length by counting
+ * its leading 1-bits. Recovers the prefixlen from the mask parse_cidr
+ * produces; the mask is always contiguous in the current call paths.
+ */
+static int netmask_to_prefix(struct in_addr mask)
+{
+    unsigned int m = ntohl(mask.s_addr);
+    int prefix = 0;
+    while (m & 0x80000000) { prefix++; m <<= 1; }
+    return prefix;
+}
+
+/*
  * Parse a "ip/prefixlen" string (e.g. "172.31.1.1/24") into an address and
  * the corresponding netmask. The input string is left untouched.
  * Returns 0 on success, -1 on error (with errno = EINVAL).
@@ -387,9 +400,7 @@ int br_set_address(const char *bridge, struct in_addr ip, struct in_addr mask)
     int ret, ifindex;
 
     /* Convert netmask back to prefix length */
-    unsigned int m = ntohl(mask.s_addr);
-    int prefix = 0;
-    while (m & 0x80000000) { prefix++; m <<= 1; }
+    int prefix = netmask_to_prefix(mask);
 
     ifindex = if_nametoindex(bridge);
     if (ifindex == 0)
@@ -443,7 +454,7 @@ int br_set_address(const char *bridge, struct in_addr ip, struct in_addr mask)
     memset(ifi, 0, sizeof(*ifi));
     ifi->ifi_family = AF_UNSPEC;
     ifi->ifi_index = ifindex;
-    ifi->ifi_change |= IFF_UP;
+    ifi->ifi_change = IFF_UP;
     ifi->ifi_flags |= IFF_UP;
 
     msg2->nlmsghdr.nlmsg_type = RTM_SETLINK;
@@ -840,9 +851,7 @@ static int cmd_delip(hypervisor_conn_t *conn, int argc, char *argv[])
     }
 
     /* Convert mask back to prefix length */
-    unsigned int m = ntohl(mask.s_addr);
-    prefix = 0;
-    while (m & 0x80000000) { prefix++; m <<= 1; }
+    prefix = netmask_to_prefix(mask);
 
     int err = br_del_address(bridge, ip, prefix);
     if (err < 0) {
@@ -1211,7 +1220,15 @@ static int br_dump_addresses(struct br_addr_entry **out, int *count)
     while (1) {
         reply->nlmsghdr.nlmsg_len = NLMSG_ALIGN(NLMSG_GOOD_SIZE);
         int r = netlink_rcv(&nlh, reply);
-        if (r <= 0)
+        if (r < 0) {
+            /* A receive error (e.g. -EMSGSIZE when a dump datagram
+             * overflows our buffer) means the dump is incomplete, not
+             * finished — report failure rather than silently returning
+             * a truncated address list as if it were complete. */
+            ret = -1;
+            goto out;
+        }
+        if (r == 0)
             break;
 
         /* Walk every nlmsg packed into this datagram */
@@ -1253,8 +1270,12 @@ static int br_dump_addresses(struct br_addr_entry **out, int *count)
             if (n == cap) {
                 int newcap = cap ? cap * 2 : 8;
                 struct br_addr_entry *tmp = realloc(entries, newcap * sizeof(*tmp));
-                if (!tmp)
-                    goto done;   /* keep whatever was collected so far */
+                if (!tmp) {
+                    /* allocation failed: report the error rather than
+                     * returning a partial dump as if it were complete. */
+                    ret = -1;
+                    goto out;
+                }
                 entries = tmp;
                 cap = newcap;
             }
@@ -1387,11 +1408,6 @@ static int cmd_show(hypervisor_conn_t *conn, int argc, char *argv[])
         hypervisor_send_reply(conn, HSC_INFO_OK, 1, "%s %s", bridge, flags_str);
     return 0;
 }
-
-
-/* brctl addr <iface> <ip/prefix> — assign IPv4 to any interface and bring it UP */
-
-/* brctl link <iface> up|down — bring an interface up or down */
 
 
 /* brctl commands */

--- a/src/hypervisor_link.c
+++ b/src/hypervisor_link.c
@@ -133,7 +133,7 @@ static int link_set_state(const char *iface, int up)
     memset(ifi, 0, sizeof(*ifi));
     ifi->ifi_family = AF_UNSPEC;
     ifi->ifi_index = ifindex;
-    ifi->ifi_change |= IFF_UP;
+    ifi->ifi_change = IFF_UP;
     if (up) ifi->ifi_flags |= IFF_UP;
 
     msg->nlmsghdr.nlmsg_type = RTM_SETLINK;

--- a/src/netlink/nl.c
+++ b/src/netlink/nl.c
@@ -232,6 +232,7 @@ extern int netlink_open(struct nl_handler *handler, int protocol)
 	socklen_t socklen;
         int sndbuf = 32768;
         int rcvbuf = 32768;
+        int saved_errno;
 
         memset(handler, 0, sizeof(*handler));
 
@@ -239,36 +240,48 @@ extern int netlink_open(struct nl_handler *handler, int protocol)
         if (handler->fd < 0)
                 return -errno;
 
-        if (setsockopt(handler->fd, SOL_SOCKET, SO_SNDBUF, 
+        if (setsockopt(handler->fd, SOL_SOCKET, SO_SNDBUF,
 		       &sndbuf, sizeof(sndbuf)) < 0)
-                return -errno;
+                goto err;
 
-        if (setsockopt(handler->fd, SOL_SOCKET, SO_RCVBUF, 
+        if (setsockopt(handler->fd, SOL_SOCKET, SO_RCVBUF,
 		       &rcvbuf,sizeof(rcvbuf)) < 0)
-                return -errno;
+                goto err;
 
         memset(&handler->local, 0, sizeof(handler->local));
         handler->local.nl_family = AF_NETLINK;
         handler->local.nl_groups = 0;
 
-        if (bind(handler->fd, (struct sockaddr*)&handler->local, 
+        if (bind(handler->fd, (struct sockaddr*)&handler->local,
 		 sizeof(handler->local)) < 0)
-                return -errno;
+                goto err;
 
         socklen = sizeof(handler->local);
-        if (getsockname(handler->fd, (struct sockaddr*)&handler->local, 
+        if (getsockname(handler->fd, (struct sockaddr*)&handler->local,
 			&socklen) < 0)
-                return -errno;
+                goto err;
 
-        if (socklen != sizeof(handler->local))
-                return -EINVAL;
+        if (socklen != sizeof(handler->local)) {
+                errno = EINVAL;
+                goto err;
+        }
 
-        if (handler->local.nl_family != AF_NETLINK)
-                return -EINVAL;
+        if (handler->local.nl_family != AF_NETLINK) {
+                errno = EINVAL;
+                goto err;
+        }
 
 	handler->seq = time(NULL);
 
         return 0;
+
+err:
+        /* socket() succeeded, so close the fd before returning the error. */
+        saved_errno = errno;
+        close(handler->fd);
+        handler->fd = -1;
+        errno = saved_errno;
+        return -errno;
 }
 
 extern int netlink_close(struct nl_handler *handler)


### PR DESCRIPTION
## Bugs fixed

### 1. `br_dump_addresses`: recv error treated as end-of-dump

When a dump datagram exceeds the 8 KiB receive buffer, `netlink_rcv` returns
`-EMSGSIZE` (MSG_TRUNC). The old code's `if (r <= 0) break` treated that as a
clean end-of-dump, returning a truncated address list as complete. `brctl show`
then printed a wrong/missing IP with no error indication.

On hosts with many IPv4 addresses (>~110 per datagram) — trivially the
7000-bridge scale the module targets — this triggers silently.

**Fix:** `r < 0` → `ret = -1; goto out`; only `r == 0` / `NLMSG_DONE` ends
the dump.

### 2. `br_dump_addresses`: realloc failure jumped to success path

On OOM mid-dump, `realloc` NULL triggered `goto done` → `ret = 0`, returning
a partial address list as complete.

**Fix:** `ret = -1; goto out` on realloc failure.

### 3. `netlink_open`: fd leak on failure paths

After `socket()` succeeded, `setsockopt`/`bind`/`getsockname` failures returned
`-errno` without `close(handler->fd)`. The leak is pre-existing in the
lxc-derived library but is now heavily exercised by the 14+ call sites in the
brctl/link modules.

**Fix:** a `goto err` label closes the fd and preserves the original errno.

## Cleanups (no functional change)

- Extract `netmask_to_prefix()` helper, eliminating a duplicated
  leading-1-bits loop (`br_set_address` / `cmd_delip`).
- Drop stale "brctl addr"/"brctl link" comments (commands moved to the
  `link` module).
- `ifi->ifi_change = IFF_UP` (not `|=`) on zeroed struct, 3 sites.

## Documentation

The "Known pitfalls" table in `doc/brctl.md` now covers the three bugs above;
the dump-parsing note explicitly mentions that recv errors (`-EMSGSIZE`) are
treated as failure.

## Testing

- `make` — clean build, no warnings
- `tests/brctl/run_all.py` — all 127 tests pass on kernel 6.19.11-1-default
