### PR TITLE
Add kernel data-plane modules (tap, tc, capture) and marker signaling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ ifeq ($(shell uname), Linux)
            src/hypervisor_brctl.c   \
            src/hypervisor_link.c   \
            src/hypervisor_tc.c   \
+           src/hypervisor_capture.c   \
            src/netlink/nl.c
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ ifeq ($(shell uname), Linux)
            src/hypervisor_iol_bridge.c     \
            src/hypervisor_brctl.c   \
            src/hypervisor_link.c   \
+           src/hypervisor_tap.c   \
            src/netlink/nl.c
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ ifeq ($(shell uname), Linux)
            src/hypervisor_iol_bridge.c     \
            src/hypervisor_brctl.c   \
            src/hypervisor_link.c   \
+           src/hypervisor_marker.c   \
            src/netlink/nl.c
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ ifeq ($(shell uname), Linux)
            src/hypervisor_iol_bridge.c     \
            src/hypervisor_brctl.c   \
            src/hypervisor_link.c   \
+           src/hypervisor_tc.c   \
            src/netlink/nl.c
 endif
 

--- a/README.md
+++ b/README.md
@@ -93,16 +93,21 @@ See [`doc/`](doc/) for per-module details.
 
 ### Hypervisor module ("hypervisor")
 
-- **hypervisor version**: Display the version of dynamips.
+- **hypervisor version**: Display the version of ubridge.
 
 ``` {.bash}
 hypervisor version
-100-0.9.12
+100-1.1.1
 ```
 
 - **hypervisor module_list**: Display the module list.
 
 ``` {.bash}
+101 marker
+101 capture
+101 tc
+101 tap
+101 link
 101 brctl
 101 iol_bridge
 101 docker
@@ -368,6 +373,15 @@ with the Berkeley Packet Filter (BPF) syntax. This filter will drop any
 packet matching the expression. It also has 1 optional argument
 *\<pcap_linktype\>* which is the PCAP link type, the default is
 Ethernet "EN10MB".
+
+##### mark
+
+(Linux only) "mark" has 1 argument "*\<filter_expression\>*" (libpcap cBPF
+syntax, like "bpf") plus optional keyword pairs `tag <id>`, `link <id>`,
+`pcap <path>` (any order). It is a **passive tap**: on a match it emits a UDP
+marker signal to a configured sink (set via the `marker` module) and, when
+`pcap <path>` is given, appends the matched packet to that pcap file — it never
+drops traffic (use "bpf" to drop). See [`doc/marker.md`](doc/marker.md).
 
 ``` {.bash}
 bridge add_packet_filter br0 "my_filter1" "delay" 50 10

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ The modules that are currently defined are given below:
 - docker : Docker management 
 - brctl : Linux bridge management
 - link : generic interface management
+- tap : persistent TAP device lifecycle (Linux only)
+- tc : kernel netem link impairment — delay/jitter/loss/dup/corrupt (Linux only)
+- capture : kernel-side AF_PACKET capture (Linux only)
+- marker : packet-filter match signals, pushed to a UDP sink (Linux only)
+
+The Linux-only modules (`tap`, `tc`, `capture`, `marker`) support the
+**kernel data plane** (frames flowing `TAP → kernel bridge → TAP`, bypassing
+ubridge's user-space NIO relay): `tap`/`brctl` build the plumbing, `tc`
+replaces the user-space filters at the qdisc level, `capture` taps the
+interface at the kernel level, and `marker` signals filter matches off band.
+See [`doc/`](doc/) for per-module details.
 
 ### Hypervisor module ("hypervisor")
 

--- a/doc/brctl.md
+++ b/doc/brctl.md
@@ -56,6 +56,7 @@ getcap $(which ubridge) # verify
 | `addif <bridge> <port>` | 2 | Enslave a port to the bridge (`RTM_SETLINK` + `IFLA_MASTER`) **and bring the port UP**. Port must pre-exist. |
 | `delif <bridge> <port>` | 2 | Release a port from a bridge. Verifies the port is actually on the given bridge; else `-EINVAL`. |
 | `addip <bridge> <ip/prefix>` | 2 | Assign an IPv4 address (`RTM_NEWADDR`) and bring the bridge UP. CIDR must include a `/` and prefix ≤ 32. |
+| `delip <bridge> <ip/prefix>` | 2 | Remove an IPv4 address from a bridge (`RTM_DELADDR`). Bad CIDR → `204`; missing bridge/IP → `207`. |
 | `setup <bridge> <ip/prefix>` | 2 | `create` + `addip` in one step. Validates the CIDR **before** creating; rolls back the bridge if `addip` fails. |
 | `show <bridge>` | 1 | Query the bridge's IPv4 address/prefix and operational flags (`UP`/`RUNNING`). |
 
@@ -70,17 +71,21 @@ All set attributes via `RTM_NEWLINK` + `IFLA_LINKINFO{kind=bridge, INFO_DATA{att
 | `setfd <bridge> <s>` | `IFLA_BR_FORWARD_DELAY` | 2–30 (seconds) |
 | `sethello <bridge> <s>` | `IFLA_BR_HELLO_TIME` | 1–10 (seconds) |
 | `setmaxage <bridge> <s>` | `IFLA_BR_MAX_AGE` | 6–40 (seconds) |
-| `setageing <bridge> <s>` | `IFLA_BR_AGEING_TIME` | ≥0 (seconds; 0 = never age) |
+| `setageing <bridge> <s>` | `IFLA_BR_AGEING_TIME` | 0–1000000 (seconds; 0 = never age) |
 | `vlanfiltering <bridge> on\|off` | `IFLA_BR_VLAN_FILTERING` | `on`/`off` |
 | `setvlanproto <bridge> <v>` | `IFLA_BR_VLAN_PROTOCOL` (u16) | `0x8100` (802.1Q) or `0x88a8` (802.1ad) |
 | `mcastsnoop <bridge> on\|off` | `IFLA_BR_MCAST_SNOOPING` | `on`/`off` |
 | `setgroupfwd <bridge> <n>` | `IFLA_BR_GROUP_FWD_MASK` | 0–65535 |
 
 > Time-valued attributes (`setfd`/`sethello`/`setmaxage`/`setageing`) are
-> converted seconds → centiseconds (×`sysconf(_SC_CLK_TK)`, i.e. ×100 on x86)
+> converted seconds → centiseconds (×`sysconf(_SC_CLK_TCK)`, i.e. ×100 on x86)
 > because the kernel stores them as `clock_t`/jiffies.
+>
+> All `on|off` commands (`stp`, `vlanfiltering`, `mcastsnoop`, and the port-level
+> `hairpin`/`isolated`) share one parser and accept `on`/`off`, `1`/`0`,
+> `yes`/`no`, `true`/`false`.
 
-### Port-level parameters (4)
+### Port-level parameters (5)
 
 All set attributes via `RTM_SETLINK` + `IFLA_PROTINFO{attr}` with
 `ifi_family = AF_BRIDGE` and `NLA_F_NESTED` on `IFLA_PROTINFO`. The port must

--- a/doc/capture.md
+++ b/doc/capture.md
@@ -1,0 +1,93 @@
+# capture module — kernel-side AF_PACKET capture
+
+The `capture` hypervisor module captures frames on a kernel interface into a
+pcap file via an `AF_PACKET` raw socket. It is exposed over the hypervisor text
+protocol as `capture <command> [args...]`.
+
+It exists for the **kernel data plane**: once frames flow `TAP → kernel bridge
+(brctl) → TAP`, they never reach ubridge's user-space NIO relay, so the
+`bridge` module's NIO-level `start_capture` can't see them. `capture` taps the
+interface at the kernel level instead.
+
+## Transport
+
+Same text protocol as the other modules. Replies are `NNN-...` (final line).
+
+## Privileges
+
+Requires `CAP_NET_RAW` (raw socket) — already granted by `sudo make install`.
+
+## Commands
+
+### `capture start_kernel <if> <pcap> [dlt]`
+
+Open an `AF_PACKET` `SOCK_RAW` socket bound to `<if>` (promiscuous), start a
+capture thread, and write frames to `<pcap>`. `<dlt>` is the pcap link type
+(default `EN10MB`). Reuses ubridge's existing pcap writer
+(`create_pcap_capture` / `pcap_capture_packet`).
+
+```
+capture start_kernel tap-gns3-e0 /tmp/cap.pcap
+100-kernel capture started on tap-gns3-e0 -> /tmp/cap.pcap
+```
+
+Only **one** kernel capture at a time (singleton); a second `start_kernel`
+while one is active → `209/EALREADY`. Missing interface → `208/ENODEV`.
+
+### `capture stop_kernel`
+
+Stop the active capture (cancel + join the thread, close the socket and pcap
+file). Idempotent: if no capture is active, replies `100-no active kernel
+capture` (not an error).
+
+```
+capture stop_kernel
+100-kernel capture stopped
+```
+
+## Status codes
+
+| Code | Meaning |
+|------|---------|
+| `100` | OK |
+| `208` | No such interface (`ENODEV`) on start |
+| `209` | A capture is already running (`EALREADY`) |
+
+## Implementation notes
+
+- **Singleton**: one global capture (`g_capture`), guarded by a mutex so
+  concurrent connections can't race.
+- **Thread model**: a dedicated thread loops on `recvfrom()`; stop is via
+  `pthread_cancel` + `pthread_join` (`recvfrom` is a cancellation point),
+  mirroring how `free_bridges()` stops the NIO listener threads. The socket is
+  closed and the pcap writer freed only after the thread has joined, so the
+  thread never touches freed state.
+- **AF_PACKET open** mirrors `nio_linux_raw.c`: `socket(PF_PACKET, SOCK_RAW,
+  htons(ETH_P_ALL))`, bind to `sockaddr_ll.sll_ifindex` (not `SO_BINDTODEVICE`),
+  `PACKET_ADD_MEMBERSHIP` promisc.
+- Reuses the existing pcap writer; link-type handling via libpcap
+  (`pcap_datalink_name_to_val`), default `DLT_EN10MB`.
+
+## Relationship to `bridge start_capture`
+
+| | `bridge start_capture` (NIO capture) | `capture start_kernel` (AF_PACKET) |
+|---|---------------------------------------|------------------------------------|
+| Taps | the user-space NIO relay loop | a kernel interface |
+| Sees | relay-bridge traffic (traditional UDP bridges) | kernel-data-plane traffic (TAP+bridge) |
+| Granularity | per-bridge (`bridge->capture`) | process singleton |
+| Both can run | yes — independent, different pcap files | yes |
+
+The **pcap file format is identical** (same writer); the **packet contents
+differ** because they tap different points. Use `bridge start_capture` for
+user-space-relay bridges, `capture start_kernel` for the kernel data plane.
+
+## Testing
+
+`tests/capture/` captures one end of a veth pair while `ping` generates
+ARP/ICMP, confirms a non-empty pcap, plus start/stop lifecycle and error paths.
+Requires `CAP_NET_ADMIN` (to create the veth) — run under sudo.
+
+```bash
+sudo make install
+cd tests/capture && sudo python3 run_all.py   # 8/8 PASS
+```

--- a/doc/gns3server-integration.md
+++ b/doc/gns3server-integration.md
@@ -133,7 +133,8 @@ bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [link <id>] 
   pcap (standard, `EN10MB`). **gns3server should name it to encode identity**,
   keyed on `link` (not `bridge`+`filter`, which collide when one bridge serves
   several links), e.g. `<project>/markers/<node_id>_<link>_<filter>.pcap`.
-- `tag`/`link`/`pcap` keyword pairs may appear in any order, each at most once.
+- `tag`/`link`/`pcap` keyword pairs may appear in any order; each is normally given
+  once (a repeat silently overwrites the earlier value — last one wins).
 
 **Disable / change** — `bridge delete_packet_filter <bridge> <name>` (closes and
 flushes the pcap; file persists). To change the BPF, delete then re-add.
@@ -241,6 +242,6 @@ capture start_kernel <if> <pcap> [dlt]                               capture sto
 # marker
 marker sink <host> <port>          marker node <id>                  marker off                     marker status
 # mark filter (under bridge)
-bridge add_packet_filter <br> <name> mark <bpf> [tag <id>] [pcap <path>]
+bridge add_packet_filter <br> <name> mark <bpf> [tag <id>] [link <id>] [pcap <path>]
 bridge delete_packet_filter <br> <name>
 ```

--- a/doc/gns3server-integration.md
+++ b/doc/gns3server-integration.md
@@ -1,0 +1,240 @@
+# ubridge ↔ gns3server integration contract
+
+This document describes what ubridge exposes to gns3server for the **kernel
+data plane** and **packet-match signaling** work. gns3server drives ubridge over
+the existing hypervisor text protocol; ubridge is inert until commanded.
+
+> Per-module details live in [`tap.md`](tap.md), [`brctl.md`](brctl.md),
+> [`tc.md`](tc.md), [`capture.md`](capture.md), [`marker.md`](marker.md).
+> This file is the cross-cutting contract for the gns3server side.
+
+---
+
+## 0. Protocol basics (recap)
+
+- One TCP control connection per ubridge (already used by gns3server). Line-based
+  text: `<module> <command> [args...]`, newline-terminated.
+- Replies: `NNN<sep>message` where `<sep>` is `-` for the final line, space for
+  intermediate lines.
+- Status codes:
+
+  | Code | Meaning |
+  |------|---------|
+  | `100` | OK |
+  | `101` | Info message (intermediate) |
+  | `203` | Bad number of parameters |
+  | `204` | Invalid parameter value |
+  | `206` | Unable to create object |
+  | `207` | Unable to delete object |
+  | `208` | Object not found (`ENODEV`) |
+  | `209` | Object already running (`EALREADY`) |
+
+- **Linux only.** The new modules (`tap`/`tc`/`capture`/`marker`) plus
+  `brctl`/`link` require ubridge installed with capabilities:
+  ```bash
+  sudo make install     # sets cap_net_admin,cap_net_raw=ep
+  ```
+
+---
+
+## 1. The kernel data plane (context)
+
+New model: frames flow `persistent TAP → kernel bridge (brctl) → TAP` **in
+kernel**, bypassing ubridge's user-space NIO relay. ubridge becomes a control
+daemon; data-plane impairment/capture must therefore also live in the kernel.
+
+| Concern | Module | Notes |
+|---------|--------|-------|
+| Persistent TAP endpoints | `tap` | per-node NIC; survives fd close so unpriv QEMU can open it |
+| Kernel bridge plumbing | `brctl` | per-link bridge; runtime add/del port = re-link |
+| Link impairment | `tc` | netem qdisc (delay/jitter/loss/dup/corrupt) |
+| Kernel capture | `capture` | AF_PACKET on an interface |
+| Match signaling + filtered capture | `marker` + `mark` filter | the focus of §3 |
+
+---
+
+## 2. Module contracts (commands gns3server issues)
+
+### tap — persistent TAP lifecycle
+| When | Command |
+|------|---------|
+| Node start | `tap create <name>` then `tap set_owner <name> <qemu_uid>` → launch QEMU with `-netdev tap,ifname=<name>,script=no` |
+| Node stop | `tap delete <name>` |
+
+`set_owner` is **required** so an unprivileged QEMU can open the persistent TAP.
+
+### brctl — kernel bridge (link plumbing)
+| When | Commands |
+|------|----------|
+| Link create | `brctl create <br>`; `brctl addif <br> <tapA>`; `brctl addif <br> <tapB>` (auto-UP) |
+| Runtime re-link | `brctl delif <br> <tap>` then `brctl addif <newbr> <tap>` |
+| Link delete | `brctl delif` on both ends, then `brctl delete <br>` |
+
+(Full STP/VLAN/port-param set in `brctl.md`.)
+
+### tc — netem impairment
+```
+tc netem set <if> [delay <ms>] [jitter <ms>] [loss <%>] [dup <%>] [corrupt <%>]
+tc reset <if>
+```
+Replaces the user-space `delay`/`packet_loss`/`corrupt` filters on the kernel
+path. Keyword/value pairs, any order; at least one required.
+
+### capture — kernel AF_PACKET capture
+```
+capture start_kernel <if> <pcap> [dlt]     # dlt defaults to EN10MB
+capture stop_kernel                          # idempotent
+```
+Singleton (one active kernel capture per ubridge). Standard pcap output,
+identical writer to `bridge start_capture`.
+
+---
+
+## 3. marker — match signaling + filtered capture (main contract)
+
+A `mark` packet filter is a **passive tap**: on BPF match it (a) pushes a UDP
+signal to a configured sink and/or (b) appends the packet to a pcap file. It
+**never drops** (use the separate `bpf` filter type to drop).
+
+### 3.1 Opt-in, per-link, user-driven
+
+Nothing happens unless gns3server configures it (typically after the user sets a
+BPF expression in the web UI). ubridge is otherwise inert (`marker_emit` is a
+no-op with no sink; no `mark` filter = no work).
+
+### 3.2 Configuration
+
+**Real-time mode** — at ubridge launch, inject (zero extra round-trips):
+```bash
+UBRIDGE_MARKER_SINK=<gns3server_ip>:<port>  UBRIDGE_MARKER_NODE=<node_id>  ubridge -H ...
+```
+or, equivalently, after launch:
+```
+marker sink <host> <port>
+marker node <node_id>
+```
+gns3server picks the UDP `<port>` (opens one listener for all ubridges) and a
+unique `<node_id>` per ubridge. (`marker off` clears the sink; `marker status`
+reports `enabled/sink/node/emitted`.)
+
+**Per-link filter** — when the user configures BPF on a link:
+```
+bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [pcap <path>]
+```
+- `<bridge>`: the ubridge bridge for this GNS3 link.
+- `<name>`: filter name (gns3server-chosen; echoed in signals, used as pcap identity).
+- `<bpf_expr>`: libpcap cBPF syntax (same as the `bpf` filter type).
+- `tag <id>`: optional correlation id echoed in the signal.
+- `pcap <path>`: optional; if given, every matched packet is appended to that
+  pcap (standard, `EN10MB`). **gns3server should name it to encode identity**, e.g.
+  `<project>/markers/<node_id>_<bridge>_<filter>.pcap`.
+- `tag`/`pcap` keyword pairs may appear in any order, each at most once.
+
+**Disable / change** — `bridge delete_packet_filter <bridge> <name>` (closes and
+flushes the pcap; file persists). To change the BPF, delete then re-add.
+
+### 3.3 What gns3server receives (real-time)
+
+One UDP datagram per match, line-based ASCII:
+```
+MARK <sec.usec> node=<id> filter=<name> tag=<tag> len=<n>\n
+```
+| Field | Meaning | When unset |
+|-------|---------|------------|
+| `MARK` | line-type marker | — |
+| `<sec.usec>` | Unix epoch, `gettimeofday`, microsecond | — |
+| `node=<id>` | the ubridge/node (`UBRIDGE_MARKER_NODE`) | `node=-` |
+| `filter=<name>` | the matched filter's name | `filter=-` |
+| `tag=<tag>` | the tag id from `mark … tag <id>` | `tag=-` |
+| `len=<n>` | matched packet length in bytes | — |
+
+Parse (Python):
+```python
+ts = float(data.split()[1])
+kv = dict(t.split(b"=",1) for t in data.split() if b"=" in t)
+# {'node':.., 'filter':.., 'tag':.., 'len':..}
+```
+> The signal carries **metadata only** — no packet bytes. `len` is the size; the
+> bytes go to the `pcap` file (if configured).
+
+### 3.4 What gns3server reads (replay)
+
+Each `pcap <path>` is a **standard pcap (`EN10MB`)** containing that filter's
+matched packets in match order, each timestamped. Read with tcpdump / tshark /
+Wireshark / PyShark natively. **The link identity is the file path** (pcap records
+carry no per-packet metadata) — gns3server tracks `path ↔ (node, link, filter)`.
+
+### 3.5 Mode matrix
+
+| Want | Configure |
+|------|-----------|
+| Real-time coloring only | set sink; `mark <bpf> [tag]` (no `pcap`) |
+| Offline replay only | `mark <bpf> [pcap <path>]` (no sink needed) |
+| Both | `mark <bpf> tag <id> pcap <path>` + sink set |
+
+---
+
+## 4. Conventions gns3server must honor
+
+- **`node_id` unique per ubridge** — it is the only way to identify the source of
+  a signal (one UDP port serves all ubridges; source UDP port is ephemeral).
+- **pcap path encodes `(node, link, filter)`** — the only link identity for replay.
+- **Timestamps** are `gettimeofday` wall-clock; comparable across ubridges on the
+  **same host**. For distributed GNS3 (ubridges on different hosts), sync clocks
+  (NTP/PTP) for a correct global timeline.
+- **`mark` is passive** — it never drops or alters traffic. To drop on match, use
+  the existing `bpf` filter type instead.
+- **One UDP listener** on gns3server for all ubridges; disambiguate by `node=`.
+
+---
+
+## 5. End-to-end flows
+
+### Real-time (web UI coloring)
+```
+user sets BPF on a link → gns3server: add_packet_filter … mark <bpf> [tag]
+match → ubridge sends MARK signal → gns3server UDP listener
+      → WebSocket → web UI colors the packet by link (node/filter)
+```
+
+### Offline replay (web UI timeline)
+```
+during run:  ubridge appends matched packets to per-link pcaps
+replay:      gns3server reads the pcaps, tags each packet with (node,link,filter),
+             sorts globally by ts → exposes timeline + per-packet APIs to web UI
+web UI:      scrubs timeline (cached index), fetches bytes/dissection on demand
+```
+A unified timeline across links is built by gns3server merging per-link pcaps by
+timestamp (each packet tagged with its source link). Do **not** physically merge
+into one pcap (classic pcap would lose per-packet link identity).
+
+---
+
+## 6. Lifecycle / teardown
+
+- `bridge delete_packet_filter` or bridge stop → the filter's pcap is closed and
+  flushed; the file persists on disk for replay.
+- `marker off` → stops signals (pcap capture, if any, continues until the filter
+  is deleted).
+- ubridge exit → all pcaps closed.
+
+---
+
+## 7. Quick reference — new commands
+
+```
+# tap
+tap create <name>                  tap set_owner <name> <uid>        tap delete <name>
+# brctl (link plumbing)
+brctl create <br>                  brctl addif <br> <tap>            brctl delif <br> <tap>        brctl delete <br>
+# tc
+tc netem set <if> [delay <ms>] [jitter <ms>] [loss <%>] [dup <%>] [corrupt <%>]
+tc reset <if>
+# capture
+capture start_kernel <if> <pcap> [dlt]                               capture stop_kernel
+# marker
+marker sink <host> <port>          marker node <id>                  marker off                     marker status
+# mark filter (under bridge)
+bridge add_packet_filter <br> <name> mark <bpf> [tag <id>] [pcap <path>]
+bridge delete_packet_filter <br> <name>
+```

--- a/doc/gns3server-integration.md
+++ b/doc/gns3server-integration.md
@@ -119,16 +119,21 @@ reports `enabled/sink/node/emitted`.)
 
 **Per-link filter** — when the user configures BPF on a link:
 ```
-bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [pcap <path>]
+bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [link <id>] [pcap <path>]
 ```
 - `<bridge>`: the ubridge bridge for this GNS3 link.
 - `<name>`: filter name (gns3server-chosen; echoed in signals, used as pcap identity).
 - `<bpf_expr>`: libpcap cBPF syntax (same as the `bpf` filter type).
 - `tag <id>`: optional correlation id echoed in the signal.
+- `link <id>`: optional link id echoed in the signal, for per-link attribution.
+  Needed when one ubridge bridge serves several GNS3 links (e.g. IOU's per-node
+  bridge): there `bridge` and `filter` are identical across links, so `link` is
+  the only way to tell signals — and pcap files — apart.
 - `pcap <path>`: optional; if given, every matched packet is appended to that
-  pcap (standard, `EN10MB`). **gns3server should name it to encode identity**, e.g.
-  `<project>/markers/<node_id>_<bridge>_<filter>.pcap`.
-- `tag`/`pcap` keyword pairs may appear in any order, each at most once.
+  pcap (standard, `EN10MB`). **gns3server should name it to encode identity**,
+  keyed on `link` (not `bridge`+`filter`, which collide when one bridge serves
+  several links), e.g. `<project>/markers/<node_id>_<link>_<filter>.pcap`.
+- `tag`/`link`/`pcap` keyword pairs may appear in any order, each at most once.
 
 **Disable / change** — `bridge delete_packet_filter <bridge> <name>` (closes and
 flushes the pcap; file persists). To change the BPF, delete then re-add.
@@ -137,7 +142,7 @@ flushes the pcap; file persists). To change the BPF, delete then re-add.
 
 One UDP datagram per match, line-based ASCII:
 ```
-MARK <sec.usec> node=<id> filter=<name> tag=<tag> len=<n>\n
+MARK <sec.usec> node=<id> filter=<name> link=<link> tag=<tag> len=<n>\n
 ```
 | Field | Meaning | When unset |
 |-------|---------|------------|
@@ -145,6 +150,7 @@ MARK <sec.usec> node=<id> filter=<name> tag=<tag> len=<n>\n
 | `<sec.usec>` | Unix epoch, `gettimeofday`, microsecond | — |
 | `node=<id>` | the ubridge/node (`UBRIDGE_MARKER_NODE`) | `node=-` |
 | `filter=<name>` | the matched filter's name | `filter=-` |
+| `link=<link>` | the link id from `mark … link <id>` | `link=-` |
 | `tag=<tag>` | the tag id from `mark … tag <id>` | `tag=-` |
 | `len=<n>` | matched packet length in bytes | — |
 
@@ -152,7 +158,7 @@ Parse (Python):
 ```python
 ts = float(data.split()[1])
 kv = dict(t.split(b"=",1) for t in data.split() if b"=" in t)
-# {'node':.., 'filter':.., 'tag':.., 'len':..}
+# {'node':.., 'filter':.., 'link':.., 'tag':.., 'len':..}
 ```
 > The signal carries **metadata only** — no packet bytes. `len` is the size; the
 > bytes go to the `pcap` file (if configured).
@@ -168,9 +174,9 @@ carry no per-packet metadata) — gns3server tracks `path ↔ (node, link, filte
 
 | Want | Configure |
 |------|-----------|
-| Real-time coloring only | set sink; `mark <bpf> [tag]` (no `pcap`) |
+| Real-time coloring only | set sink; `mark <bpf> [tag] [link]` (no `pcap`) |
 | Offline replay only | `mark <bpf> [pcap <path>]` (no sink needed) |
-| Both | `mark <bpf> tag <id> pcap <path>` + sink set |
+| Both | `mark <bpf> link <id> tag <id> pcap <path>` + sink set |
 
 ---
 

--- a/doc/link.md
+++ b/doc/link.md
@@ -105,8 +105,10 @@ Invalid state (not `up`/`down`) → `204/EINVAL`. Missing interface →
 | Code | Meaning |
 |------|---------|
 | `100` | OK |
+| `203` | Bad number of parameters |
 | `204` | Invalid parameter value |
 | `206` | Unable to create object |
+| `207` | Unable to delete object |
 
 ## Typical workflow
 

--- a/doc/marker.md
+++ b/doc/marker.md
@@ -1,0 +1,131 @@
+# marker — packet-filter match signals
+
+The `mark` packet filter (under the `bridge` module) and the `marker` module
+together let the controller **react to / assert on specific traffic**: a
+matching packet emits a one-line **marker signal** pushed as a UDP datagram to a
+configured sink (gns3server). The filter is a **passive tap** — it signals but
+does not drop.
+
+## Why
+
+For traffic-driven automation: "when DHCP Discover is seen, notify my test",
+"assert packet X appeared", sync a test on a flow event. Signals are pushed out
+of band (UDP), so the controller doesn't have to poll.
+
+## Architecture
+
+```
+per-node ubridge (mark filter, on match)  ──UDP──▶  gns3server:port (consumer)
+```
+
+Each per-node ubridge is a pure **UDP client**: on match, one `sendto` to the
+configured sink. No listener, no thread, no per-node server. `marker_emit` is a
+no-op when no sink is set, so `mark` filters are cheap when unused.
+
+## The `mark` packet filter
+
+Registered under the `bridge` module like the other filter types:
+
+```
+bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>]
+```
+
+- Matches via libpcap cBPF (`pcap_offline_filter`), exactly like the `bpf`
+  filter type.
+- On match → emits a marker signal. **Always returns PASS** (the packet
+  continues; to drop on match use the separate `bpf` filter type).
+- `<id>` is an optional tag echoed in the signal, for correlation.
+
+```
+bridge add_packet_filter br0 dhcp_probe mark "udp port 67" tag 11
+100-Filter 'dhcp_probe' configured in position 1
+```
+
+## The `marker` module
+
+```
+marker sink <host> <port>   # set the UDP sink (gns3server)
+marker node <id>            # node id echoed in signals
+marker off                  # clear the sink
+marker status               # enabled / sink / node / emitted count
+```
+
+Configuration can also be injected at launch via environment variables (so the
+controller doesn't need extra round-trips):
+
+- `UBRIDGE_MARKER_SINK=host:port`
+- `UBRIDGE_MARKER_NODE=<id>`
+
+```
+marker sink 127.0.0.1 9000
+100-marker sink set to 127.0.0.1:9000
+marker node qemu-r1
+100-marker node set to qemu-r1
+marker status
+101-enabled=1 sink=127.0.0.1:9000 node=qemu-r1 emitted=3
+100-OK
+```
+
+## Signal format
+
+One UDP datagram per match, line-based:
+
+```
+MARK <sec.usec> node=<id> filter=<name> tag=<tag> len=<n>
+```
+
+`node`/`tag` are `-` when unset. The controller parses the line and dispatches
+by `node` / `filter` / `tag`.
+
+## Status codes
+
+| Code | Meaning |
+|------|---------|
+| `100` | OK |
+| `204` | Invalid sink port / bad value |
+| `206` | Could not resolve / set sink |
+
+## Consumer side (gns3server)
+
+Out of ubridge's scope, but ~10 lines of Python: open a UDP socket, `recvfrom`,
+split the `MARK` line into key/values, dispatch by tag (or expose a
+`wait_for(tag, timeout)` helper for test synchronization).
+
+```python
+s = socket.socket(socket.AF_UNIX if False else socket.AF_INET, socket.SOCK_DGRAM)
+s.bind(("0.0.0.0", 9000))
+while True:
+    data, _ = s.recvfrom(4096)
+    kv = dict(t.split(b"=",1) for t in data.split() if b"=" in t)
+    # {'filter': b'dhcp_probe', 'tag': b'11', 'node': b'qemu-r1', 'len': b'342'}
+```
+
+## Implementation notes
+
+- **`mark` filter** (`src/packet_filter.c`, `#ifdef __linux__`): mirrors the
+  `bpf` filter type. The filter name is captured at create time
+  (`create_mark_filter` runs after `add_packet_filter` has `strdup`'d the name),
+  because the handler only ever receives `filter->data`, not the name.
+- **`marker` engine** (`src/marker.h`, `src/hypervisor_marker.c`): `marker_emit`
+  formats the line and `sendto`'s a cached UDP socket under a mutex; the socket
+  is (re)opened when a sink is set. UDP `sendto` is atomic for small datagrams,
+  so no per-event buffering/thread is needed.
+- Linux-only (`#ifdef __linux__` + Makefile Linux block), consistent with
+  tap/tc/capture.
+
+## Testing
+
+`tests/marker/` stands up a UDP listener as the sink, injects an IP frame into
+a UDP-NIO bridge with a `mark "ip" tag 7` filter, and asserts the signal arrives
+with the right node/filter/tag/len, that the frame was still relayed (passive),
+and that `marker off` stops the signals.
+
+> Note: ubridge's UDP NIO `connect()`s to the configured remote, so it only
+> accepts packets whose source is that remote — the test binds the injector to
+> the NIO's remote port so the injected frame is accepted.
+
+**Pure user-space (UDP + libpcap cBPF) — no `CAP_NET_ADMIN` needed, no sudo:**
+
+```bash
+cd tests/marker && python3 run_all.py   # 8/8 PASS
+```

--- a/doc/marker.md
+++ b/doc/marker.md
@@ -91,7 +91,7 @@ marker sink 127.0.0.1 9000
 marker node qemu-r1
 100-marker node set to qemu-r1
 marker status
-101-enabled=1 sink=127.0.0.1:9000 node=qemu-r1 emitted=3
+101 enabled=1 sink=127.0.0.1:9000 node=qemu-r1 emitted=3
 100-OK
 ```
 

--- a/doc/marker.md
+++ b/doc/marker.md
@@ -27,7 +27,7 @@ no-op when no sink is set, so `mark` filters are cheap when unused.
 Registered under the `bridge` module like the other filter types:
 
 ```
-bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [pcap <path>]
+bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [link <id>] [pcap <path>]
 ```
 
 - Matches via libpcap cBPF (`pcap_offline_filter`), exactly like the `bpf`
@@ -36,23 +36,32 @@ bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [pcap <path>
   is given, appends the packet to that pcap file. **Always returns PASS** (the
   packet continues; to drop on match use the separate `bpf` filter type).
 - `tag <id>` is an optional id echoed in the signal, for correlation.
+- `link <id>` is an optional id echoed in the signal, for **topology link
+  attribution**. Distinct from `tag` (free-form correlation): when one ubridge
+  bridge carries several links — notably IOU's per-node `IOL-BRIDGE`, where
+  every link shares the same bridge — `bridge` and `filter` are identical
+  across those links, so the controller needs `link` to tell their signals (and
+  pcap paths) apart. ubridge treats it as opaque and echoes it verbatim.
 - `pcap <path>` is an optional path to a pcap file (standard, `EN10MB`) that
   **accumulates every matched packet** for this filter (open once on setup,
   append one record per match, closed when the filter is deleted). This is a
   BPF-filtered capture: only matches land in the file. gns3server names the
-  path per link/filter (e.g. `<project>/markers/<node>_<bridge>_<filter>.pcap`)
-  and reads it back for offline replay/analysis with tcpdump/Wireshark/PyShark.
-- Keyword pairs (`tag`, `pcap`) may appear in any order.
+  path per link (e.g. `<project>/markers/<node>_<link>_<filter>.pcap`), keyed
+  on `link` — `bridge`+`filter` collide when one bridge serves several links
+  (IOU) — and reads it back for offline replay/analysis with
+  tcpdump/Wireshark/PyShark.
+- Keyword pairs (`tag`, `link`, `pcap`) may appear in any order.
 
 ```
 bridge add_packet_filter br0 dhcp_probe mark "udp port 67" tag 11
 100-Filter 'dhcp_probe' configured in position 1
 
-bridge add_packet_filter br0 ip_cap mark ip pcap /tmp/ip.pcap
-100-Filter 'ip_cap' configured in position 2
+# per-link attribution (e.g. one port of a shared IOU bridge):
+bridge add_packet_filter br0 icmp_l3 mark "icmp" link 3 pcap /tmp/icmp_l3.pcap
+100-Filter 'icmp_l3' configured in position 2
 
-# both at once (real-time signal + on-disk capture):
-bridge add_packet_filter br0 dhcp mark "udp port 67" tag 11 pcap /tmp/dhcp.pcap
+# all at once (real-time signal + per-link + on-disk capture):
+bridge add_packet_filter br0 dhcp mark "udp port 67" tag 11 link 3 pcap /tmp/dhcp.pcap
 ```
 
 > The `pcap` option writes a **standard pcap** (same writer as
@@ -91,11 +100,12 @@ marker status
 One UDP datagram per match, line-based:
 
 ```
-MARK <sec.usec> node=<id> filter=<name> tag=<tag> len=<n>
+MARK <sec.usec> node=<id> filter=<name> link=<link> tag=<tag> len=<n>
 ```
 
-`node`/`tag` are `-` when unset. The controller parses the line and dispatches
-by `node` / `filter` / `tag`.
+`node`/`link`/`tag` are `-` when unset. The controller parses the line and
+dispatches by `node` / `link` / `filter` / `tag` (`link` disambiguates signals
+that share a bridge+filter across multiple links).
 
 ## Status codes
 
@@ -108,8 +118,8 @@ by `node` / `filter` / `tag`.
 ## Consumer side (gns3server)
 
 Out of ubridge's scope, but ~10 lines of Python: open a UDP socket, `recvfrom`,
-split the `MARK` line into key/values, dispatch by tag (or expose a
-`wait_for(tag, timeout)` helper for test synchronization).
+split the `MARK` line into key/values, dispatch by `node`/`link`/`tag` (or
+expose a `wait_for(tag, timeout)` helper for test synchronization).
 
 ```python
 s = socket.socket(socket.AF_UNIX if False else socket.AF_INET, socket.SOCK_DGRAM)

--- a/doc/marker.md
+++ b/doc/marker.md
@@ -27,19 +27,39 @@ no-op when no sink is set, so `mark` filters are cheap when unused.
 Registered under the `bridge` module like the other filter types:
 
 ```
-bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>]
+bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [pcap <path>]
 ```
 
 - Matches via libpcap cBPF (`pcap_offline_filter`), exactly like the `bpf`
   filter type.
-- On match → emits a marker signal. **Always returns PASS** (the packet
-  continues; to drop on match use the separate `bpf` filter type).
-- `<id>` is an optional tag echoed in the signal, for correlation.
+- On match → emits a marker signal (if a sink is set) **and**, if `pcap <path>`
+  is given, appends the packet to that pcap file. **Always returns PASS** (the
+  packet continues; to drop on match use the separate `bpf` filter type).
+- `tag <id>` is an optional id echoed in the signal, for correlation.
+- `pcap <path>` is an optional path to a pcap file (standard, `EN10MB`) that
+  **accumulates every matched packet** for this filter (open once on setup,
+  append one record per match, closed when the filter is deleted). This is a
+  BPF-filtered capture: only matches land in the file. gns3server names the
+  path per link/filter (e.g. `<project>/markers/<node>_<bridge>_<filter>.pcap`)
+  and reads it back for offline replay/analysis with tcpdump/Wireshark/PyShark.
+- Keyword pairs (`tag`, `pcap`) may appear in any order.
 
 ```
 bridge add_packet_filter br0 dhcp_probe mark "udp port 67" tag 11
 100-Filter 'dhcp_probe' configured in position 1
+
+bridge add_packet_filter br0 ip_cap mark ip pcap /tmp/ip.pcap
+100-Filter 'ip_cap' configured in position 2
+
+# both at once (real-time signal + on-disk capture):
+bridge add_packet_filter br0 dhcp mark "udp port 67" tag 11 pcap /tmp/dhcp.pcap
 ```
+
+> The `pcap` option writes a **standard pcap** (same writer as
+> `bridge start_capture` / `capture start_kernel`), so any pcap tool reads it
+> with no conversion. Which link a file came from is encoded in its **path**
+> (gns3server's naming) — classic pcap records carry no per-packet metadata, so
+> the link identity lives at the file level, not inside the pcap.
 
 ## The `marker` module
 

--- a/doc/marker.md
+++ b/doc/marker.md
@@ -157,5 +157,5 @@ and that `marker off` stops the signals.
 **Pure user-space (UDP + libpcap cBPF) — no `CAP_NET_ADMIN` needed, no sudo:**
 
 ```bash
-cd tests/marker && python3 run_all.py   # 8/8 PASS
+cd tests/marker && python3 run_all.py   # 13/13 PASS
 ```

--- a/doc/tap.md
+++ b/doc/tap.md
@@ -94,7 +94,7 @@ Missing device → `207/ENODEV`.
 |------|---------|
 | `100` | OK |
 | `204` | Invalid parameter (name too long, bad uid) |
-| `206` | Unable to create / set owner (`EEXIST`, `EBUSY`, `ENODEV`) |
+| `206` | Unable to create / set owner (`EBUSY`, `ENODEV`) |
 | `207` | Unable to delete (`ENODEV`) |
 
 ## Typical workflow

--- a/doc/tap.md
+++ b/doc/tap.md
@@ -1,0 +1,148 @@
+# tap module — persistent TAP device lifecycle
+
+The `tap` hypervisor module creates, owns, and destroys **persistent** TAP
+devices via `/dev/net/tun` ioctls. It is exposed over the hypervisor text
+protocol as `tap <command> [args...]`.
+
+It exists to support the kernel-side data-plane model: frames flow between a
+persistent TAP and a kernel bridge (managed by the [`brctl`](brctl.md) module)
+entirely in the kernel, never through ubridge's user-space NIO relay. A
+persistent TAP survives its creating fd being closed, so an unprivileged
+emulator (QEMU) can open it later by name — provided ownership was handed over
+with `set_owner`.
+
+`tap` does **not** add TAPs to bridges (that's `brctl addif`) and does **not**
+open a TAP as an NIO relay (that's the `bridge` module's `add_nio_tap`, which
+opens a non-persistent TAP tied to a bridge). `tap` is purely lifecycle.
+
+## Transport
+
+Same text protocol as the other modules: newline-terminated commands, first
+token is the module (`tap`), second is the command, rest are arguments.
+Replies are `NNN-...` (final line).
+
+## Privileges
+
+All commands require `CAP_NET_ADMIN`. In practice ubridge is granted
+capabilities on install:
+
+```bash
+sudo make install       # sets cap_net_admin,cap_net_raw=ep on the binary
+getcap $(which ubridge) # verify
+```
+
+Clients (gns3server) need neither privileges nor `/dev/net/tun` access — they
+talk to ubridge over TCP, and ubridge does the ioctl work with its own
+capabilities.
+
+## Commands
+
+### `tap create <name>`
+
+Create a persistent TAP device (`open /dev/net/tun` + `TUNSETIFF`
+`IFF_TAP|IFF_NO_PI|IFF_TUN_EXCL` + `TUNSETPERSIST(1)`, then close). The device
+starts **DOWN**; bring it up with `brctl addif` (which auto-UPs a port) or
+`link set <name> up`.
+
+| Arg | Description |
+|-----|-------------|
+| `<name>` | Device name, ≤ 15 chars (`IFNAMSIZ - 1`) |
+
+```
+tap create tap-gns3-e0
+100-Persistent TAP tap-gns3-e0 created
+```
+
+Duplicate name → `206/EBUSY` (the `IFF_TUN_EXCL` flag rejects re-attaching to
+an existing device). Name too long → `204`.
+
+### `tap set_owner <name> <uid>`
+
+Set the owner (uid) of a persistent TAP device. **Critical for the
+unprivileged-QEMU case**: after this, the given uid can `open()` the device.
+Implemented by re-attaching to the existing device (`TUNSETIFF`) then
+`ioctl(TUNSETOWNER, uid)`.
+
+| Arg | Description |
+|-----|-------------|
+| `<name>` | An existing persistent TAP device |
+| `<uid>` | Numeric user ID (0–4294967295) |
+
+```
+tap set_owner tap-gns3-e0 1000
+100-Owner 1000 set on TAP tap-gns3-e0
+```
+
+Non-numeric or out-of-range uid → `204`. Missing device → `206/ENODEV`.
+
+### `tap delete <name>`
+
+Delete a persistent TAP device (`TUNSETIFF` re-attach + `TUNSETPERSIST(0)`,
+then close — the kernel destroys the device once the last fd is closed and
+persistence is off).
+
+```
+tap delete tap-gns3-e0
+100-TAP tap-gns3-e0 deleted
+```
+
+Missing device → `207/ENODEV`.
+
+## Status codes
+
+| Code | Meaning |
+|------|---------|
+| `100` | OK |
+| `204` | Invalid parameter (name too long, bad uid) |
+| `206` | Unable to create / set owner (`EEXIST`, `EBUSY`, `ENODEV`) |
+| `207` | Unable to delete (`ENODEV`) |
+
+## Typical workflow
+
+The canonical GNS3 use case — a QEMU node opens a persistent TAP that is
+already bridged:
+
+```
+tap create tap-node-e0                       # ubridge creates persistent TAP
+tap set_owner tap-node-e0 <qemu-uid>         # hand it to the emulator's uid
+brctl create proj-br                         # per-link kernel bridge
+brctl addif proj-br tap-node-e0              # enslave TAP (+ auto UP)
+# QEMU launches with: -netdev tap,ifname=tap-node-e0,script=no,...
+```
+
+No root, no `/dev/net/tun` access for the emulator beyond owning the device —
+ubridge does the privileged setup via ioctls.
+
+## Implementation notes
+
+- **Stateless.** A persistent TAP survives its creating fd closing, so each
+  command opens `/dev/net/tun`, re-attaches to the named device with
+  `TUNSETIFF`, performs the ioctl, and closes the fd. ubridge holds no
+  per-device fd or registry — same "one call, one transaction" style as
+  `brctl`/`link`.
+- **Re-attach semantics.** Calling `TUNSETIFF` with the name of an existing
+  persistent TAP attaches to it (it does not create a new one). `create` adds
+  `IFF_TUN_EXCL` so a duplicate create is rejected with `EBUSY` rather than
+  silently re-attaching.
+- **Error handling.** Helpers return a **negative errno** (not `-1`); command
+  handlers report `strerror(-err)`.
+- **`IFF_TUN_EXCL`** has been in `<linux/if_tun.h>` since 2.6.26; the module
+  defines it locally as a fallback for very old headers.
+
+## Testing
+
+Smoke-tested on **Linux 6.x** (x86_64), ubridge with
+`cap_net_admin,cap_net_raw=ep`. Kernel-side state verified with
+`ip -o link show <name>` and `ip -o tuntap show` after each command.
+
+```bash
+sudo make install                 # install fresh binary with caps
+cd tests/tap
+sudo python3 test_basic.py        # single suite
+sudo python3 run_all.py           # or all suites
+```
+
+The suite covers lifecycle (create/owner/delete), error paths (duplicate
+create → 206, missing delete → 207, overlong name / bad uid → 204), and the
+`brctl addif` integration that wires a persistent TAP into a kernel bridge.
+```

--- a/doc/tc.md
+++ b/doc/tc.md
@@ -1,0 +1,119 @@
+# tc module — kernel netem link impairment
+
+The `tc` hypervisor module attaches and removes a **netem** qdisc at the root
+of an interface, providing kernel-side link impairment (delay / jitter / loss /
+duplicate / corrupt). It is exposed over the hypervisor text protocol as
+`tc <command> [args...]`.
+
+It exists for the **kernel data plane**: once frames flow `TAP → kernel bridge
+(brctl) → TAP`, they never reach ubridge's user-space NIO relay, so the
+`bridge` module's user-space packet filters (`delay` / `packet_loss` / `corrupt`
+/ `bpf`) no longer see the traffic. The impairment has to live in the kernel
+qdisc instead. `tc` is that kernel-side replacement for the subset of user-space
+filters that netem covers (delay/jitter/loss/dup/corrupt).
+
+## Transport
+
+Same text protocol as the other modules: newline-terminated commands, first
+token is the module (`tc`), second is the command, rest are arguments. Replies
+are `NNN-...` (final line).
+
+## Privileges
+
+Requires `CAP_NET_ADMIN` (attaching a qdisc). In practice ubridge is granted
+capabilities on install:
+
+```bash
+sudo make install       # sets cap_net_admin,cap_net_raw=ep on the binary
+getcap $(which ubridge) # verify
+```
+
+## Commands
+
+### `tc netem set <if> [delay <ms>] [jitter <ms>] [loss <%>] [dup <%>] [corrupt <%>]`
+
+Attach/replace a netem qdisc at the root of `<if>` (`RTM_NEWQDISC`,
+`NLM_F_CREATE|REPLACE`). At least one option must be given. Keyword/value
+pairs, any order:
+
+| Option | Unit | Notes |
+|--------|------|-------|
+| `delay <ms>` | milliseconds (may be fractional) | added latency |
+| `jitter <ms>` | milliseconds | latency variation |
+| `loss <%>` | 0–100 | random packet loss |
+| `dup <%` | 0–100 | random duplication |
+| `corrupt <%>` | 0–100 | random corruption |
+
+```
+tc netem set tap-gns3-e0 delay 100 jitter 10 loss 5
+100-netem set on tap-gns3-e0
+```
+
+Verify in the kernel with `tc qdisc show dev <if>`:
+```
+qdisc netem 8002: root refcnt 2 limit 1000 delay 100.0ms  10.0ms loss 5% ...
+```
+(`tc` prints jitter as a bare second time value after delay, not the word
+"jitter".)
+
+Bad value / unknown keyword → `204`. Bad number of params → `203`. Missing
+interface → `206/ENODEV`.
+
+### `tc reset <if>`
+
+Remove the root qdisc of `<if>` (`RTM_DELQDISC`). This removes whatever root
+qdisc is attached (netem or the default); the kernel re-creates a default
+qdisc.
+
+```
+tc reset tap-gns3-e0
+100-qdisc reset on tap-gns3-e0
+```
+
+Missing interface → `207/ENODEV`.
+
+## Status codes
+
+| Code | Meaning |
+|------|---------|
+| `100` | OK |
+| `203` | Bad number of parameters |
+| `204` | Invalid parameter value |
+| `206` | Unable to create / set (`ENODEV`, etc.) |
+| `207` | Unable to delete (`ENODEV`) |
+
+## Implementation notes
+
+- **netem ABI** (per `net/sched/sch_netem.c` `netem_change`): `TCA_OPTIONS` is a
+  nested attribute whose payload begins with a raw `struct tc_netem_qopt`
+  (mandatory), optionally followed by nested `TCA_NETEM_*` attributes.
+- **delay/jitter** are sent as `TCA_NETEM_LATENCY64` / `TCA_NETEM_JITTER64`
+  (s64 nanoseconds), which override the legacy u32 struct fields and avoid the
+  `PSCHED_TICKS` unit ambiguity. **loss / duplicate** go in the struct fields as
+  `probability × 2³²`; **corrupt** is the fixed-size `TCA_NETEM_CORRUPT` nested
+  attr (`struct tc_netem_corrupt { probability, correlation }`).
+- Uses ubridge's netlink library (`src/netlink/nl.c`); `nla_put_buffer` carries
+  the s64 `*64` attrs and the corrupt struct (no `nla_put_u64` needed).
+- Helpers return a **negative errno**; command handlers report `strerror(-err)`.
+
+## Relationship to user-space packet filters
+
+| user-space filter (`bridge add_packet_filter`) | kernel equivalent |
+|------------------------------------------------|-------------------|
+| `delay`(+`jitter`) | `tc netem delay/jitter` |
+| `packet_loss` | `tc netem loss` |
+| `corrupt` | `tc netem corrupt` |
+| (none) | `tc netem dup` (no user-space dup filter) |
+| `frequency_drop` (exact every-Nth) | none — netem loss is stochastic; exact needs eBPF |
+| `bpf` (cBPF drop filter) | none — needs tc clsact eBPF (not implemented) |
+
+## Testing
+
+`tests/tc/` attaches netem to a throwaway dummy interface and reads it back with
+`tc qdisc show` (delay/jitter/loss/dup/corrupt), plus reset and error paths.
+Requires `CAP_NET_ADMIN` — run under sudo.
+
+```bash
+sudo make install
+cd tests/tc && sudo python3 run_all.py   # 17/17 PASS
+```

--- a/doc/tc.md
+++ b/doc/tc.md
@@ -41,7 +41,7 @@ pairs, any order:
 | `delay <ms>` | milliseconds (may be fractional) | added latency |
 | `jitter <ms>` | milliseconds | latency variation |
 | `loss <%>` | 0–100 | random packet loss |
-| `dup <%` | 0–100 | random duplication |
+| `dup <%>` | 0–100 | random duplication |
 | `corrupt <%>` | 0–100 | random corruption |
 
 ```

--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -42,6 +42,7 @@
 #include "hypervisor_brctl.h"
 #include "hypervisor_link.h"
 #include "hypervisor_tc.h"
+#include "hypervisor_capture.h"
 #endif
 #include "ubridge.h"
 
@@ -506,6 +507,7 @@ int run_hypervisor(char *ip_addr, int tcp_port)
    hypervisor_brctl_init();
    hypervisor_link_init();
    hypervisor_tc_init();
+   hypervisor_capture_init();
 #endif
 
    signal(SIGPIPE, SIG_IGN);

--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -41,6 +41,7 @@
 #include "hypervisor_iol_bridge.h"
 #include "hypervisor_brctl.h"
 #include "hypervisor_link.h"
+#include "hypervisor_tap.h"
 #endif
 #include "ubridge.h"
 
@@ -504,6 +505,7 @@ int run_hypervisor(char *ip_addr, int tcp_port)
    hypervisor_iol_bridge_init();
    hypervisor_brctl_init();
    hypervisor_link_init();
+   hypervisor_tap_init();
 #endif
 
    signal(SIGPIPE, SIG_IGN);

--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -41,6 +41,7 @@
 #include "hypervisor_iol_bridge.h"
 #include "hypervisor_brctl.h"
 #include "hypervisor_link.h"
+#include "hypervisor_tc.h"
 #endif
 #include "ubridge.h"
 
@@ -504,6 +505,7 @@ int run_hypervisor(char *ip_addr, int tcp_port)
    hypervisor_iol_bridge_init();
    hypervisor_brctl_init();
    hypervisor_link_init();
+   hypervisor_tc_init();
 #endif
 
    signal(SIGPIPE, SIG_IGN);

--- a/src/hypervisor.c
+++ b/src/hypervisor.c
@@ -41,6 +41,7 @@
 #include "hypervisor_iol_bridge.h"
 #include "hypervisor_brctl.h"
 #include "hypervisor_link.h"
+#include "marker.h"
 #endif
 #include "ubridge.h"
 
@@ -504,6 +505,7 @@ int run_hypervisor(char *ip_addr, int tcp_port)
    hypervisor_iol_bridge_init();
    hypervisor_brctl_init();
    hypervisor_link_init();
+   hypervisor_marker_init();
 #endif
 
    signal(SIGPIPE, SIG_IGN);

--- a/src/hypervisor_capture.c
+++ b/src/hypervisor_capture.c
@@ -1,0 +1,249 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2015 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * capture — kernel-side packet capture via AF_PACKET.
+ *
+ * Captures frames on a kernel interface (typically a persistent TAP created by
+ * the tap module, or a bridge managed by brctl) into a pcap file. Needed for
+ * the kernel data plane: once frames flow TAP -> kernel bridge -> TAP they
+ * never reach ubridge's user-space NIO relay, so the bridge module's NIO-level
+ * capture can't see them. This opens an AF_PACKET raw socket bound to the
+ * interface and writes frames to pcap, reusing the existing pcap writer
+ * (create_pcap_capture / pcap_capture_packet / free_pcap_capture).
+ *
+ * Model: a single (singleton) capture at a time, driven by a dedicated thread
+ * that loops on recvfrom(). Stop is via pthread_cancel + pthread_join (recvfrom
+ * is a cancellation point), mirroring how free_bridges() stops the NIO listener
+ * threads — no cooperative stop flag.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+
+#include "ubridge.h"
+#include "pcap_capture.h"
+#include "hypervisor.h"
+#include "hypervisor_capture.h"
+
+typedef struct {
+    pcap_capture_t *cap;        /* reused pcap writer (NULL when idle) */
+    int sock;                   /* AF_PACKET raw socket (-1 when idle) */
+    pthread_t tid;              /* capture thread */
+    volatile int running;       /* 1 while the capture thread is alive */
+    char ifname[IFNAMSIZ];      /* captured interface (informational) */
+} kernel_capture_t;
+
+static kernel_capture_t g_capture = { .cap = NULL, .sock = -1, .running = 0 };
+static pthread_mutex_t g_capture_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/* Capture thread: read frames from the AF_PACKET socket, write to pcap. */
+static void *capture_thread(void *arg)
+{
+    kernel_capture_t *kc = (kernel_capture_t *)arg;
+    unsigned char buf[65535];
+
+    for (;;) {
+        ssize_t n = recvfrom(kc->sock, buf, sizeof(buf), 0, NULL, NULL);
+        if (n <= 0) {
+            if (n < 0 && errno == EINTR)
+                continue;
+            break;
+        }
+        pcap_capture_packet(kc->cap, buf, (size_t)n);
+    }
+
+    return NULL;
+}
+
+/* Start capturing <ifname> into <pcap_file> (link type <dlt>, default EN10MB). */
+static int capture_start(const char *ifname, const char *pcap_file, const char *dlt)
+{
+    struct sockaddr_ll sll;
+    struct packet_mreq mreq;
+    int ifindex, fd, err;
+
+    pthread_mutex_lock(&g_capture_lock);
+
+    if (g_capture.running) {
+        pthread_mutex_unlock(&g_capture_lock);
+        return -EALREADY;
+    }
+
+    ifindex = if_nametoindex(ifname);
+    if (ifindex == 0) {
+        pthread_mutex_unlock(&g_capture_lock);
+        return -ENODEV;
+    }
+
+    g_capture.cap = create_pcap_capture(pcap_file, dlt ? dlt : "EN10MB");
+    if (!g_capture.cap) {
+        err = (errno != 0) ? -errno : -EIO;
+        pthread_mutex_unlock(&g_capture_lock);
+        return err;
+    }
+
+    fd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    if (fd < 0) {
+        err = -errno;
+        free_pcap_capture(g_capture.cap);
+        g_capture.cap = NULL;
+        pthread_mutex_unlock(&g_capture_lock);
+        return err;
+    }
+
+    memset(&sll, 0, sizeof(sll));
+    sll.sll_family = AF_PACKET;
+    sll.sll_protocol = htons(ETH_P_ALL);
+    sll.sll_ifindex = ifindex;
+    if (bind(fd, (struct sockaddr *)&sll, sizeof(sll)) < 0) {
+        err = -errno;
+        close(fd);
+        free_pcap_capture(g_capture.cap);
+        g_capture.cap = NULL;
+        pthread_mutex_unlock(&g_capture_lock);
+        return err;
+    }
+
+    /* Promiscuous mode (best-effort) to catch all frames on the interface. */
+    memset(&mreq, 0, sizeof(mreq));
+    mreq.mr_ifindex = ifindex;
+    mreq.mr_type = PACKET_MR_PROMISC;
+    setsockopt(fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
+
+    g_capture.sock = fd;
+    strncpy(g_capture.ifname, ifname, IFNAMSIZ - 1);
+    g_capture.ifname[IFNAMSIZ - 1] = '\0';
+
+    err = pthread_create(&g_capture.tid, NULL, capture_thread, &g_capture);
+    if (err != 0) {
+        close(g_capture.sock);
+        g_capture.sock = -1;
+        g_capture.ifname[0] = '\0';
+        free_pcap_capture(g_capture.cap);
+        g_capture.cap = NULL;
+        pthread_mutex_unlock(&g_capture_lock);
+        return -err;   /* pthread_create returns an errno value */
+    }
+
+    g_capture.running = 1;
+    pthread_mutex_unlock(&g_capture_lock);
+    return 0;
+}
+
+/* Stop the active capture. Returns 0 or -ENODEV if none is active. */
+static int capture_stop(void)
+{
+    pthread_mutex_lock(&g_capture_lock);
+
+    if (!g_capture.running) {
+        pthread_mutex_unlock(&g_capture_lock);
+        return -ENODEV;
+    }
+
+    /* Cancel first, then join: the thread dies at recvfrom() (a cancellation
+     * point) before we close its socket / free the pcap writer it references. */
+    pthread_cancel(g_capture.tid);
+    pthread_join(g_capture.tid, NULL);
+
+    g_capture.running = 0;
+    close(g_capture.sock);
+    g_capture.sock = -1;
+    free_pcap_capture(g_capture.cap);
+    g_capture.cap = NULL;
+    g_capture.ifname[0] = '\0';
+
+    pthread_mutex_unlock(&g_capture_lock);
+    return 0;
+}
+
+/* --------------------------------------------------------------------------
+ * Command handlers
+ * -------------------------------------------------------------------------- */
+
+/* capture start_kernel <if> <pcap> [dlt] */
+static int cmd_start_kernel(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    char *ifname = argv[0];
+    char *pcap_file = argv[1];
+    char *dlt = (argc >= 3) ? argv[2] : NULL;
+    int err = capture_start(ifname, pcap_file, dlt);
+
+    if (err < 0) {
+        int code = (-err == EALREADY) ? HSC_ERR_START :
+                   (-err == ENODEV) ? HSC_ERR_UNK_OBJ : HSC_ERR_FILE;
+        hypervisor_send_reply(conn, code, 1, "Could not start kernel capture: %s", strerror(-err));
+        return -1;
+    }
+
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "kernel capture started on %s -> %s", ifname, pcap_file);
+    return 0;
+}
+
+/* capture stop_kernel */
+static int cmd_stop_kernel(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    int err = capture_stop();
+
+    if (err < 0) {
+        if (-err == ENODEV) {
+            /* Idempotent: no active capture is not an error. */
+            hypervisor_send_reply(conn, HSC_INFO_OK, 1, "no active kernel capture");
+            return 0;
+        }
+        hypervisor_send_reply(conn, HSC_ERR_STOP, 1, "Could not stop kernel capture: %s", strerror(-err));
+        return -1;
+    }
+
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "kernel capture stopped");
+    return 0;
+}
+
+/* --------------------------------------------------------------------------
+ * Command table + module registration
+ * -------------------------------------------------------------------------- */
+
+static hypervisor_cmd_t capture_cmd_array[] = {
+   /* start_kernel <if> <pcap> [dlt] */
+   { "start_kernel", 2, 3, cmd_start_kernel, NULL },
+   { "stop_kernel",  0, 0, cmd_stop_kernel, NULL },
+   { NULL, -1, -1, NULL, NULL },
+};
+
+/* Hypervisor capture initialization */
+int hypervisor_capture_init(void)
+{
+   hypervisor_module_t *module;
+
+   module = hypervisor_register_module("capture", NULL);
+   assert(module != NULL);
+
+   hypervisor_register_cmd_array(module, capture_cmd_array);
+   return(0);
+}

--- a/src/hypervisor_capture.h
+++ b/src/hypervisor_capture.h
@@ -1,0 +1,26 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2015 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef HYPERVISOR_CAPTURE_H_
+#define HYPERVISOR_CAPTURE_H_
+
+int hypervisor_capture_init(void);
+
+#endif /* !HYPERVISOR_CAPTURE_H_ */

--- a/src/hypervisor_marker.c
+++ b/src/hypervisor_marker.c
@@ -1,0 +1,261 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2015 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * marker engine + `marker` hypervisor module.
+ *
+ * marker_emit() is called by the `mark` packet filter on a match. It sends one
+ * UDP datagram per match to a configured sink (gns3server), fire-and-forget.
+ * No listener thread, no accept loop, no per-node server — ubridge is purely a
+ * UDP client here. The sink/node are configured via `marker sink`/`marker node`
+ * commands or the UBRIDGE_MARKER_SINK / UBRIDGE_MARKER_NODE env vars at start.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netdb.h>
+
+#include "hypervisor.h"
+#include "marker.h"
+
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+static int             g_fd = -1;                 /* cached UDP socket, -1 if none */
+static struct sockaddr_storage g_sink;            /* resolved sink address */
+static socklen_t       g_sink_len = 0;
+static int             g_enabled = 0;             /* sink configured? */
+static char            g_sink_display[72] = "";   /* "host:port" for status */
+static char            g_node[64] = "";           /* node id echoed in signals */
+static unsigned long   g_emitted = 0;
+
+/* --------------------------------------------------------------------------
+ * Engine
+ * -------------------------------------------------------------------------- */
+
+/* Configure the UDP sink. Resolves <host>:<port>, (re)opens the socket. 0 or -errno. */
+int marker_set_sink(const char *host, int port)
+{
+    struct addrinfo hints, *res = NULL;
+    char port_str[16];
+    int fd, err;
+
+    if (!host || port <= 0 || port > 65535)
+        return -EINVAL;
+
+    snprintf(port_str, sizeof(port_str), "%d", port);
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = PF_UNSPEC;
+    hints.ai_socktype = SOCK_DGRAM;
+
+    err = getaddrinfo(host, port_str, &hints, &res);
+    if (err != 0)
+        return -ENOENT;   /* unresolvable / unreachable */
+
+    fd = socket(res->ai_family, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        err = errno;
+        freeaddrinfo(res);
+        return -err;
+    }
+
+    pthread_mutex_lock(&g_lock);
+    if (g_fd >= 0)
+        close(g_fd);
+    g_fd = fd;
+    memset(&g_sink, 0, sizeof(g_sink));
+    memcpy(&g_sink, res->ai_addr, res->ai_addrlen);
+    g_sink_len = res->ai_addrlen;
+    g_enabled = 1;
+    snprintf(g_sink_display, sizeof(g_sink_display), "%s:%d", host, port);
+    pthread_mutex_unlock(&g_lock);
+
+    freeaddrinfo(res);
+    return 0;
+}
+
+int marker_clear_sink(void)
+{
+    pthread_mutex_lock(&g_lock);
+    if (g_fd >= 0)
+        close(g_fd);
+    g_fd = -1;
+    g_enabled = 0;
+    g_sink_len = 0;
+    g_sink_display[0] = '\0';
+    pthread_mutex_unlock(&g_lock);
+    return 0;
+}
+
+void marker_set_node(const char *node_id)
+{
+    pthread_mutex_lock(&g_lock);
+    if (node_id) {
+        strncpy(g_node, node_id, sizeof(g_node) - 1);
+        g_node[sizeof(g_node) - 1] = '\0';
+    } else {
+        g_node[0] = '\0';
+    }
+    pthread_mutex_unlock(&g_lock);
+}
+
+/* Emit one marker signal (UDP, fire-and-forget). No-op if no sink. */
+void marker_emit(const char *filter_name, const char *tag, size_t len)
+{
+    char line[256];
+    struct timeval tv;
+    const char *node;
+    int n;
+
+    pthread_mutex_lock(&g_lock);
+    if (!g_enabled || g_fd < 0) {
+        pthread_mutex_unlock(&g_lock);
+        return;
+    }
+
+    node = g_node[0] ? g_node : "-";
+    gettimeofday(&tv, NULL);
+    n = snprintf(line, sizeof(line),
+                 "MARK %lu.%06lu node=%s filter=%s tag=%s len=%zu\n",
+                 (unsigned long)tv.tv_sec, (unsigned long)tv.tv_usec,
+                 node,
+                 filter_name ? filter_name : "-",
+                 tag ? tag : "-",
+                 len);
+    if (n > 0)
+        sendto(g_fd, line, strlen(line), 0, (struct sockaddr *)&g_sink, g_sink_len);
+    g_emitted++;
+    pthread_mutex_unlock(&g_lock);
+}
+
+int marker_status(marker_status_t *out)
+{
+    if (!out)
+        return -EINVAL;
+    pthread_mutex_lock(&g_lock);
+    out->enabled = g_enabled;
+    snprintf(out->sink, sizeof(out->sink), "%s", g_sink_display);
+    snprintf(out->node, sizeof(out->node), "%s", g_node);
+    out->emitted = g_emitted;
+    pthread_mutex_unlock(&g_lock);
+    return 0;
+}
+
+/* --------------------------------------------------------------------------
+ * `marker` module commands
+ * -------------------------------------------------------------------------- */
+
+/* marker sink <host> <port> */
+static int cmd_sink(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    char *host = argv[0];
+    char *end;
+    long port = strtol(argv[1], &end, 10);
+    int err;
+
+    if (end == argv[1] || *end != '\0' || port <= 0 || port > 65535) {
+        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "invalid port '%s' (1-65535)", argv[1]);
+        return -1;
+    }
+    err = marker_set_sink(host, (int)port);
+    if (err < 0) {
+        hypervisor_send_reply(conn, HSC_ERR_CREATE, 1, "could not set marker sink %s:%ld: %s", host, port, strerror(-err));
+        return -1;
+    }
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "marker sink set to %s:%ld", host, port);
+    return 0;
+}
+
+/* marker node <id> */
+static int cmd_node(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    marker_set_node(argv[0]);
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "marker node set to %s", argv[0]);
+    return 0;
+}
+
+/* marker off — clear the sink */
+static int cmd_off(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    marker_clear_sink();
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "marker sink cleared");
+    return 0;
+}
+
+/* marker status */
+static int cmd_status(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    marker_status_t s;
+    marker_status(&s);
+    hypervisor_send_reply(conn, HSC_INFO_MSG, 0, "enabled=%d sink=%s node=%s emitted=%lu",
+                          s.enabled, s.enabled ? s.sink : "(none)", s.node[0] ? s.node : "(none)", s.emitted);
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "OK");
+    return 0;
+}
+
+static hypervisor_cmd_t marker_cmd_array[] = {
+   { "sink",   2, 2, cmd_sink,   NULL },   /* <host> <port> */
+   { "node",   1, 1, cmd_node,   NULL },
+   { "off",    0, 0, cmd_off,    NULL },
+   { "status", 0, 0, cmd_status, NULL },
+   { NULL, -1, -1, NULL, NULL },
+};
+
+/* Parse "host:port" (last colon) → set sink. */
+static void marker_env_sink(const char *s)
+{
+    const char *colon = strrchr(s, ':');
+    char host[64];
+    int port;
+    if (!colon)
+        return;
+    if ((size_t)(colon - s) >= sizeof(host))
+        return;
+    memcpy(host, s, colon - s);
+    host[colon - s] = '\0';
+    port = atoi(colon + 1);
+    if (port > 0)
+        marker_set_sink(host, port);
+}
+
+/* Hypervisor marker initialization */
+int hypervisor_marker_init(void)
+{
+   hypervisor_module_t *module;
+
+   module = hypervisor_register_module("marker", NULL);
+   assert(module != NULL);
+   hypervisor_register_cmd_array(module, marker_cmd_array);
+
+   /* Env defaults: controller may inject at launch instead of via commands. */
+   {
+      const char *sink = getenv("UBRIDGE_MARKER_SINK");
+      const char *node = getenv("UBRIDGE_MARKER_NODE");
+      if (sink && *sink)
+          marker_env_sink(sink);
+      if (node && *node)
+          marker_set_node(node);
+   }
+   return(0);
+}

--- a/src/hypervisor_marker.c
+++ b/src/hypervisor_marker.c
@@ -121,7 +121,7 @@ void marker_set_node(const char *node_id)
 }
 
 /* Emit one marker signal (UDP, fire-and-forget). No-op if no sink. */
-void marker_emit(const char *filter_name, const char *tag, size_t len)
+void marker_emit(const char *filter_name, const char *tag, const char *link, size_t len)
 {
     char line[256];
     struct timeval tv;
@@ -137,10 +137,11 @@ void marker_emit(const char *filter_name, const char *tag, size_t len)
     node = g_node[0] ? g_node : "-";
     gettimeofday(&tv, NULL);
     n = snprintf(line, sizeof(line),
-                 "MARK %lu.%06lu node=%s filter=%s tag=%s len=%zu\n",
+                 "MARK %lu.%06lu node=%s filter=%s link=%s tag=%s len=%zu\n",
                  (unsigned long)tv.tv_sec, (unsigned long)tv.tv_usec,
                  node,
                  filter_name ? filter_name : "-",
+                 link ? link : "-",
                  tag ? tag : "-",
                  len);
     if (n > 0)

--- a/src/hypervisor_tap.c
+++ b/src/hypervisor_tap.c
@@ -50,6 +50,17 @@
 #define IFF_TUN_EXCL 0x8000
 #endif
 
+/*
+ * Return 0 if <name> is an existing network device, -ENODEV otherwise.
+ * set_owner and delete must refuse a non-existent name: TUNSETIFF would
+ * otherwise silently CREATE a transient TAP instead of failing. Mirrors the
+ * if_nametoindex existence check used by the brctl module (e.g. br_enslave_if).
+ */
+static int tap_require_existing(const char *name)
+{
+    return if_nametoindex(name) ? 0 : -ENODEV;
+}
+
 /* --------------------------------------------------------------------------
  * Low-level helpers — each returns 0 on success or a negative errno.
  * -------------------------------------------------------------------------- */
@@ -107,6 +118,10 @@ static int tap_set_owner(const char *name, uid_t uid)
 {
     int fd, ret;
 
+    ret = tap_require_existing(name);
+    if (ret < 0)
+        return ret;
+
     fd = tap_attach(name, 0);
     if (fd < 0)
         return fd;
@@ -125,6 +140,10 @@ static int tap_set_owner(const char *name, uid_t uid)
 static int tap_delete(const char *name)
 {
     int fd, ret;
+
+    ret = tap_require_existing(name);
+    if (ret < 0)
+        return ret;
 
     fd = tap_attach(name, 0);
     if (fd < 0)

--- a/src/hypervisor_tap.c
+++ b/src/hypervisor_tap.c
@@ -1,0 +1,240 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2015 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * tap — persistent TAP device lifecycle management.
+ *
+ * Creates/destroys persistent TAP devices (/dev/net/tun) and assigns
+ * ownership so that an unprivileged emulator (QEMU) can open them. This
+ * lets ubridge act purely as a control-plane daemon: the data plane flows
+ * kernel-side between the persistent TAP and a kernel bridge (see the
+ * brctl module), never through ubridge's user-space NIO relay.
+ *
+ * Design: stateless. A persistent TAP survives its creating fd being
+ * closed, so each command opens /dev/net/tun, re-attaches to the named
+ * device with TUNSETIFF, performs the ioctl, and closes the fd. ubridge
+ * holds no per-device fd or registry.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <linux/if_tun.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "hypervisor.h"
+#include "hypervisor_tap.h"
+
+/* IFF_TUN_EXCL has been in <linux/if_tun.h> since 2.6.26; guard anyway. */
+#ifndef IFF_TUN_EXCL
+#define IFF_TUN_EXCL 0x8000
+#endif
+
+/* --------------------------------------------------------------------------
+ * Low-level helpers — each returns 0 on success or a negative errno.
+ * -------------------------------------------------------------------------- */
+
+/*
+ * Open /dev/net/tun and attach to a TAP device named <name>.
+ * <extra_flags> is OR'd into IFF_TAP|IFF_NO_PI (create passes IFF_TUN_EXCL
+ * so re-attaching to an existing device fails with -EBUSY; set_owner and
+ * delete pass 0 because they must attach to an already-persistent device).
+ * Returns the fd on success, or a negative errno on failure.
+ */
+static int tap_attach(const char *name, int extra_flags)
+{
+    struct ifreq ifr;
+    int fd;
+
+    fd = open("/dev/net/tun", O_RDWR);
+    if (fd < 0)
+        return -errno;
+
+    memset(&ifr, 0, sizeof(ifr));
+    ifr.ifr_flags = IFF_TAP | IFF_NO_PI | extra_flags;
+    strncpy(ifr.ifr_name, name, IFNAMSIZ);
+
+    if (ioctl(fd, TUNSETIFF, &ifr) < 0) {
+        int err = errno;
+        close(fd);
+        return -err;
+    }
+
+    return fd;
+}
+
+/* Create a persistent TAP device named <name>. */
+static int tap_create(const char *name)
+{
+    int fd, ret;
+
+    fd = tap_attach(name, IFF_TUN_EXCL);
+    if (fd < 0)
+        return fd;
+
+    if (ioctl(fd, TUNSETPERSIST, 1) < 0) {
+        ret = -errno;
+        close(fd);
+        return ret;
+    }
+
+    close(fd);
+    return 0;
+}
+
+/* Set the owner (uid) of a persistent TAP device named <name>. */
+static int tap_set_owner(const char *name, uid_t uid)
+{
+    int fd, ret;
+
+    fd = tap_attach(name, 0);
+    if (fd < 0)
+        return fd;
+
+    if (ioctl(fd, TUNSETOWNER, uid) < 0) {
+        ret = -errno;
+        close(fd);
+        return ret;
+    }
+
+    close(fd);
+    return 0;
+}
+
+/* Delete a persistent TAP device named <name>. */
+static int tap_delete(const char *name)
+{
+    int fd, ret;
+
+    fd = tap_attach(name, 0);
+    if (fd < 0)
+        return fd;
+
+    if (ioctl(fd, TUNSETPERSIST, 0) < 0) {
+        ret = -errno;
+        close(fd);
+        return ret;
+    }
+
+    close(fd);
+    return 0;
+}
+
+/* --------------------------------------------------------------------------
+ * Command handlers
+ * -------------------------------------------------------------------------- */
+
+/* tap create <name> */
+static int cmd_create(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    char *name = argv[0];
+    int err;
+
+    if (strlen(name) >= IFNAMSIZ) {
+        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "TAP name %s too long (max %d)", name, IFNAMSIZ - 1);
+        return -1;
+    }
+
+    err = tap_create(name);
+    if (err < 0) {
+        hypervisor_send_reply(conn, HSC_ERR_CREATE, 1, "Could not create TAP %s: %s", name, strerror(-err));
+        return -1;
+    }
+
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "Persistent TAP %s created", name);
+    return 0;
+}
+
+/* tap set_owner <name> <uid> */
+static int cmd_set_owner(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    char *name = argv[0];
+    char *end;
+    unsigned long uid;
+    int err;
+
+    if (strlen(name) >= IFNAMSIZ) {
+        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "TAP name %s too long (max %d)", name, IFNAMSIZ - 1);
+        return -1;
+    }
+
+    errno = 0;
+    uid = strtoul(argv[1], &end, 10);
+    if (errno != 0 || end == argv[1] || *end != '\0' || uid > 0xFFFFFFFFu) {
+        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "Invalid uid %s", argv[1]);
+        return -1;
+    }
+
+    err = tap_set_owner(name, (uid_t)uid);
+    if (err < 0) {
+        hypervisor_send_reply(conn, HSC_ERR_CREATE, 1, "Could not set owner on TAP %s: %s", name, strerror(-err));
+        return -1;
+    }
+
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "Owner %u set on TAP %s", (unsigned)uid, name);
+    return 0;
+}
+
+/* tap delete <name> */
+static int cmd_delete(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    char *name = argv[0];
+    int err;
+
+    if (strlen(name) >= IFNAMSIZ) {
+        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "TAP name %s too long (max %d)", name, IFNAMSIZ - 1);
+        return -1;
+    }
+
+    err = tap_delete(name);
+    if (err < 0) {
+        hypervisor_send_reply(conn, HSC_ERR_DELETE, 1, "Could not delete TAP %s: %s", name, strerror(-err));
+        return -1;
+    }
+
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "TAP %s deleted", name);
+    return 0;
+}
+
+/* --------------------------------------------------------------------------
+ * Command table + module registration
+ * -------------------------------------------------------------------------- */
+
+static hypervisor_cmd_t tap_cmd_array[] = {
+   { "create",    1, 1, cmd_create,    NULL },
+   { "set_owner", 2, 2, cmd_set_owner, NULL },
+   { "delete",    1, 1, cmd_delete,    NULL },
+   { NULL, -1, -1, NULL, NULL },
+};
+
+/* Hypervisor tap initialization */
+int hypervisor_tap_init(void)
+{
+   hypervisor_module_t *module;
+
+   module = hypervisor_register_module("tap", NULL);
+   assert(module != NULL);
+
+   hypervisor_register_cmd_array(module, tap_cmd_array);
+   return(0);
+}

--- a/src/hypervisor_tap.h
+++ b/src/hypervisor_tap.h
@@ -1,0 +1,26 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2015 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef HYPERVISOR_TAP_H_
+#define HYPERVISOR_TAP_H_
+
+int hypervisor_tap_init(void);
+
+#endif /* !HYPERVISOR_TAP_H_ */

--- a/src/hypervisor_tc.c
+++ b/src/hypervisor_tc.c
@@ -74,7 +74,8 @@ static int tc_netem_replace(const char *ifname,
                             int has_delay, double delay_ms,
                             int has_jitter, double jitter_ms,
                             int has_loss, unsigned int loss_pct,
-                            int has_dup, unsigned int dup_pct)
+                            int has_dup, unsigned int dup_pct,
+                            int has_corrupt, unsigned int corrupt_pct)
 {
     struct nl_handler nlh;
     struct nlmsg *msg = NULL, *reply = NULL;
@@ -130,6 +131,14 @@ static int tc_netem_replace(const char *ifname,
     if (has_jitter) {
         v64 = (long long)(jitter_ms * 1000000.0);  /* ms -> ns */
         nla_put_buffer(msg, TCA_NETEM_JITTER64, &v64, sizeof(v64));
+    }
+    if (has_corrupt) {
+        /* TCA_NETEM_CORRUPT: fixed-size struct {probability, correlation},
+         * probability encoded like loss/dup (p * 2^32); correlation 0. */
+        struct tc_netem_corrupt c;
+        memset(&c, 0, sizeof(c));
+        c.probability = netem_percent(corrupt_pct);
+        nla_put_buffer(msg, TCA_NETEM_CORRUPT, &c, sizeof(c));
     }
     nla_end_nested(msg, opts);
 
@@ -188,13 +197,13 @@ out:
  * Command handlers
  * -------------------------------------------------------------------------- */
 
-/* tc netem set <if> [delay <ms>] [jitter <ms>] [loss <%>] [dup <%>] */
+/* tc netem set <if> [delay <ms>] [jitter <ms>] [loss <%>] [dup <%>] [corrupt <%>] */
 static int cmd_netem(hypervisor_conn_t *conn, int argc, char *argv[])
 {
     const char *ifname;
-    int has_delay = 0, has_jitter = 0, has_loss = 0, has_dup = 0, any = 0;
+    int has_delay = 0, has_jitter = 0, has_loss = 0, has_dup = 0, has_corrupt = 0, any = 0;
     double delay_ms = 0.0, jitter_ms = 0.0;
-    unsigned int loss_pct = 0, dup_pct = 0;
+    unsigned int loss_pct = 0, dup_pct = 0, corrupt_pct = 0;
     int i, err;
 
     if (strcmp(argv[0], "set") != 0) {
@@ -217,14 +226,15 @@ static int cmd_netem(hypervisor_conn_t *conn, int argc, char *argv[])
             if (kw[0] == 'd') { delay_ms = ms; has_delay = 1; }
             else { jitter_ms = ms; has_jitter = 1; }
             any = 1;
-        } else if (!strcmp(kw, "loss") || !strcmp(kw, "dup")) {
+        } else if (!strcmp(kw, "loss") || !strcmp(kw, "dup") || !strcmp(kw, "corrupt")) {
             long p = strtol(val, &end, 10);
             if (end == val || *end != '\0' || p < 0 || p > 100) {
                 hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "invalid %s percent '%s' (0-100)", kw, val);
                 return -1;
             }
-            if (kw[0] == 'l') { loss_pct = (unsigned int)p; has_loss = 1; }
-            else { dup_pct = (unsigned int)p; has_dup = 1; }
+            if (!strcmp(kw, "loss")) { loss_pct = (unsigned int)p; has_loss = 1; }
+            else if (!strcmp(kw, "dup")) { dup_pct = (unsigned int)p; has_dup = 1; }
+            else { corrupt_pct = (unsigned int)p; has_corrupt = 1; }
             any = 1;
         } else {
             hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "unknown netem option '%s'", kw);
@@ -238,12 +248,13 @@ static int cmd_netem(hypervisor_conn_t *conn, int argc, char *argv[])
     }
 
     if (!any) {
-        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "no impairment specified (use delay/jitter/loss/dup)");
+        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "no impairment specified (use delay/jitter/loss/dup/corrupt)");
         return -1;
     }
 
     err = tc_netem_replace(ifname, has_delay, delay_ms, has_jitter, jitter_ms,
-                           has_loss, loss_pct, has_dup, dup_pct);
+                           has_loss, loss_pct, has_dup, dup_pct,
+                           has_corrupt, corrupt_pct);
     if (err < 0) {
         hypervisor_send_reply(conn, HSC_ERR_CREATE, 1, "Could not set netem on %s: %s", ifname, strerror(-err));
         return -1;
@@ -273,8 +284,8 @@ static int cmd_reset(hypervisor_conn_t *conn, int argc, char *argv[])
  * -------------------------------------------------------------------------- */
 
 static hypervisor_cmd_t tc_cmd_array[] = {
-   /* netem set <if> [delay <ms>] [jitter <ms>] [loss <%>] [dup <%>] */
-   { "netem", 4, 10, cmd_netem, NULL },
+   /* netem set <if> [delay <ms>] [jitter <ms>] [loss <%>] [dup <%>] [corrupt <%>] */
+   { "netem", 4, 12, cmd_netem, NULL },
    { "reset", 1, 1, cmd_reset, NULL },
    { NULL, -1, -1, NULL, NULL },
 };

--- a/src/hypervisor_tc.c
+++ b/src/hypervisor_tc.c
@@ -201,7 +201,7 @@ out:
 static int cmd_netem(hypervisor_conn_t *conn, int argc, char *argv[])
 {
     const char *ifname;
-    int has_delay = 0, has_jitter = 0, has_loss = 0, has_dup = 0, has_corrupt = 0, any = 0;
+    int has_delay = 0, has_jitter = 0, has_loss = 0, has_dup = 0, has_corrupt = 0;
     double delay_ms = 0.0, jitter_ms = 0.0;
     unsigned int loss_pct = 0, dup_pct = 0, corrupt_pct = 0;
     int i, err;
@@ -225,7 +225,6 @@ static int cmd_netem(hypervisor_conn_t *conn, int argc, char *argv[])
             }
             if (kw[0] == 'd') { delay_ms = ms; has_delay = 1; }
             else { jitter_ms = ms; has_jitter = 1; }
-            any = 1;
         } else if (!strcmp(kw, "loss") || !strcmp(kw, "dup") || !strcmp(kw, "corrupt")) {
             long p = strtol(val, &end, 10);
             if (end == val || *end != '\0' || p < 0 || p > 100) {
@@ -235,7 +234,6 @@ static int cmd_netem(hypervisor_conn_t *conn, int argc, char *argv[])
             if (!strcmp(kw, "loss")) { loss_pct = (unsigned int)p; has_loss = 1; }
             else if (!strcmp(kw, "dup")) { dup_pct = (unsigned int)p; has_dup = 1; }
             else { corrupt_pct = (unsigned int)p; has_corrupt = 1; }
-            any = 1;
         } else {
             hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "unknown netem option '%s'", kw);
             return -1;
@@ -244,11 +242,6 @@ static int cmd_netem(hypervisor_conn_t *conn, int argc, char *argv[])
 
     if (i < argc) {
         hypervisor_send_reply(conn, HSC_ERR_BAD_PARAM, 1, "option '%s' missing its value", argv[i]);
-        return -1;
-    }
-
-    if (!any) {
-        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "no impairment specified (use delay/jitter/loss/dup/corrupt)");
         return -1;
     }
 

--- a/src/hypervisor_tc.c
+++ b/src/hypervisor_tc.c
@@ -1,0 +1,292 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2015 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * tc — kernel traffic-control (netem) impairment via netlink.
+ *
+ * Attaches/replaces a netem qdisc at the root of an interface, and removes
+ * it. This provides the kernel-side link impairment (delay/jitter/loss/dup)
+ * that the kernel data plane needs: once frames flow TAP -> kernel bridge ->
+ * TAP (not through ubridge's user-space NIO relay), the bridge module's
+ * user-space packet filters no longer see the traffic, so the impairment has
+ * to live in the kernel qdisc.
+ *
+ * netem ABI (per net/sched/sch_netem.c netem_change): TCA_OPTIONS is a nested
+ * attribute whose payload begins with a raw struct tc_netem_qopt (mandatory),
+ * optionally followed by nested TCA_NETEM_* attributes. delay/jitter are sent
+ * as TCA_NETEM_LATENCY64/JITTER64 (s64 nanoseconds), which override the
+ * legacy u32 struct fields and avoid the PSCHED_TICKS unit ambiguity; loss and
+ * duplicate go in the struct fields as a probability scaled by 2^32.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+
+#include <net/if.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <linux/pkt_sched.h>
+
+#include "netlink/nl.h"
+#include "hypervisor.h"
+#include "hypervisor_tc.h"
+
+/* Default netem fifo limit (packets). */
+#define NETEM_LIMIT_DEFAULT 1000
+
+/* --------------------------------------------------------------------------
+ * netlink helpers — return 0 on success or a negative errno.
+ * -------------------------------------------------------------------------- */
+
+/*
+ * Convert a percentage (0..100) to netem's u32 probability encoding
+ * (p * 2^32). 0 => none, ~0 => all; see netem loss_event()/netem_enqueue().
+ */
+static unsigned int netem_percent(unsigned int percent)
+{
+    if (percent == 0)
+        return 0;
+    if (percent >= 100)
+        return 0xFFFFFFFFu;
+    return (unsigned int)(((unsigned long long)percent << 32) / 100);
+}
+
+/* Attach/replace a netem qdisc at the root of <ifname>. Returns 0 or -errno. */
+static int tc_netem_replace(const char *ifname,
+                            int has_delay, double delay_ms,
+                            int has_jitter, double jitter_ms,
+                            int has_loss, unsigned int loss_pct,
+                            int has_dup, unsigned int dup_pct)
+{
+    struct nl_handler nlh;
+    struct nlmsg *msg = NULL, *reply = NULL;
+    struct tcmsg *tcm;
+    struct rtattr *opts;
+    struct tc_netem_qopt qopt;
+    long long v64;
+    int ifindex, ret;
+
+    ifindex = if_nametoindex(ifname);
+    if (ifindex == 0)
+        return -ENODEV;
+
+    ret = netlink_open(&nlh, NETLINK_ROUTE);
+    if (ret < 0)
+        return ret;
+
+    msg = nlmsg_alloc(NLMSG_GOOD_SIZE);
+    reply = nlmsg_alloc(NLMSG_GOOD_SIZE);
+    if (!msg || !reply) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    tcm = (struct tcmsg *)nlmsg_data(msg);
+    memset(tcm, 0, sizeof(*tcm));
+    tcm->tcm_family = AF_UNSPEC;
+    tcm->tcm_ifindex = ifindex;
+    tcm->tcm_parent = TC_H_ROOT;   /* root qdisc */
+
+    msg->nlmsghdr.nlmsg_type = RTM_NEWQDISC;
+    msg->nlmsghdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
+    msg->nlmsghdr.nlmsg_len = NLMSG_LENGTH(sizeof(struct tcmsg));
+
+    nla_put_string(msg, TCA_KIND, "netem");
+
+    /* TCA_OPTIONS = raw struct tc_netem_qopt (mandatory prefix) + nested attrs */
+    opts = nla_begin_nested(msg, TCA_OPTIONS);
+    opts->rta_type |= NLA_F_NESTED;
+
+    memset(&qopt, 0, sizeof(qopt));
+    qopt.limit = NETEM_LIMIT_DEFAULT;
+    qopt.loss = has_loss ? netem_percent(loss_pct) : 0;
+    qopt.duplicate = has_dup ? netem_percent(dup_pct) : 0;
+    /* latency/jitter left 0; overridden unambiguously (ns) by *64 below */
+    memcpy(NLMSG_TAIL(&msg->nlmsghdr), &qopt, sizeof(qopt));
+    msg->nlmsghdr.nlmsg_len += sizeof(qopt);
+
+    if (has_delay) {
+        v64 = (long long)(delay_ms * 1000000.0);   /* ms -> ns */
+        nla_put_buffer(msg, TCA_NETEM_LATENCY64, &v64, sizeof(v64));
+    }
+    if (has_jitter) {
+        v64 = (long long)(jitter_ms * 1000000.0);  /* ms -> ns */
+        nla_put_buffer(msg, TCA_NETEM_JITTER64, &v64, sizeof(v64));
+    }
+    nla_end_nested(msg, opts);
+
+    ret = netlink_transaction(&nlh, msg, reply);
+
+out:
+    nlmsg_free(msg);
+    nlmsg_free(reply);
+    netlink_close(&nlh);
+    return ret;
+}
+
+/* Remove the root qdisc of <ifname>. Returns 0 or -errno. */
+static int tc_reset(const char *ifname)
+{
+    struct nl_handler nlh;
+    struct nlmsg *msg = NULL, *reply = NULL;
+    struct tcmsg *tcm;
+    int ifindex, ret;
+
+    ifindex = if_nametoindex(ifname);
+    if (ifindex == 0)
+        return -ENODEV;
+
+    ret = netlink_open(&nlh, NETLINK_ROUTE);
+    if (ret < 0)
+        return ret;
+
+    msg = nlmsg_alloc(NLMSG_GOOD_SIZE);
+    reply = nlmsg_alloc(NLMSG_GOOD_SIZE);
+    if (!msg || !reply) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    tcm = (struct tcmsg *)nlmsg_data(msg);
+    memset(tcm, 0, sizeof(*tcm));
+    tcm->tcm_family = AF_UNSPEC;
+    tcm->tcm_ifindex = ifindex;
+    tcm->tcm_parent = TC_H_ROOT;
+
+    msg->nlmsghdr.nlmsg_type = RTM_DELQDISC;
+    msg->nlmsghdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    msg->nlmsghdr.nlmsg_len = NLMSG_LENGTH(sizeof(struct tcmsg));
+
+    ret = netlink_transaction(&nlh, msg, reply);
+
+out:
+    nlmsg_free(msg);
+    nlmsg_free(reply);
+    netlink_close(&nlh);
+    return ret;
+}
+
+/* --------------------------------------------------------------------------
+ * Command handlers
+ * -------------------------------------------------------------------------- */
+
+/* tc netem set <if> [delay <ms>] [jitter <ms>] [loss <%>] [dup <%>] */
+static int cmd_netem(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    const char *ifname;
+    int has_delay = 0, has_jitter = 0, has_loss = 0, has_dup = 0, any = 0;
+    double delay_ms = 0.0, jitter_ms = 0.0;
+    unsigned int loss_pct = 0, dup_pct = 0;
+    int i, err;
+
+    if (strcmp(argv[0], "set") != 0) {
+        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "unknown netem action '%s' (expected 'set')", argv[0]);
+        return -1;
+    }
+
+    ifname = argv[1];
+
+    /* keyword/value pairs from argv[2] on */
+    for (i = 2; i + 1 < argc; i += 2) {
+        char *kw = argv[i], *val = argv[i + 1], *end;
+
+        if (!strcmp(kw, "delay") || !strcmp(kw, "jitter")) {
+            double ms = strtod(val, &end);
+            if (end == val || *end != '\0' || ms < 0) {
+                hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "invalid %s value '%s'", kw, val);
+                return -1;
+            }
+            if (kw[0] == 'd') { delay_ms = ms; has_delay = 1; }
+            else { jitter_ms = ms; has_jitter = 1; }
+            any = 1;
+        } else if (!strcmp(kw, "loss") || !strcmp(kw, "dup")) {
+            long p = strtol(val, &end, 10);
+            if (end == val || *end != '\0' || p < 0 || p > 100) {
+                hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "invalid %s percent '%s' (0-100)", kw, val);
+                return -1;
+            }
+            if (kw[0] == 'l') { loss_pct = (unsigned int)p; has_loss = 1; }
+            else { dup_pct = (unsigned int)p; has_dup = 1; }
+            any = 1;
+        } else {
+            hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "unknown netem option '%s'", kw);
+            return -1;
+        }
+    }
+
+    if (i < argc) {
+        hypervisor_send_reply(conn, HSC_ERR_BAD_PARAM, 1, "option '%s' missing its value", argv[i]);
+        return -1;
+    }
+
+    if (!any) {
+        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "no impairment specified (use delay/jitter/loss/dup)");
+        return -1;
+    }
+
+    err = tc_netem_replace(ifname, has_delay, delay_ms, has_jitter, jitter_ms,
+                           has_loss, loss_pct, has_dup, dup_pct);
+    if (err < 0) {
+        hypervisor_send_reply(conn, HSC_ERR_CREATE, 1, "Could not set netem on %s: %s", ifname, strerror(-err));
+        return -1;
+    }
+
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "netem set on %s", ifname);
+    return 0;
+}
+
+/* tc reset <if> */
+static int cmd_reset(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    char *ifname = argv[0];
+    int err = tc_reset(ifname);
+
+    if (err < 0) {
+        hypervisor_send_reply(conn, HSC_ERR_DELETE, 1, "Could not reset qdisc on %s: %s", ifname, strerror(-err));
+        return -1;
+    }
+
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "qdisc reset on %s", ifname);
+    return 0;
+}
+
+/* --------------------------------------------------------------------------
+ * Command table + module registration
+ * -------------------------------------------------------------------------- */
+
+static hypervisor_cmd_t tc_cmd_array[] = {
+   /* netem set <if> [delay <ms>] [jitter <ms>] [loss <%>] [dup <%>] */
+   { "netem", 4, 10, cmd_netem, NULL },
+   { "reset", 1, 1, cmd_reset, NULL },
+   { NULL, -1, -1, NULL, NULL },
+};
+
+/* Hypervisor tc initialization */
+int hypervisor_tc_init(void)
+{
+   hypervisor_module_t *module;
+
+   module = hypervisor_register_module("tc", NULL);
+   assert(module != NULL);
+
+   hypervisor_register_cmd_array(module, tc_cmd_array);
+   return(0);
+}

--- a/src/hypervisor_tc.h
+++ b/src/hypervisor_tc.h
@@ -1,0 +1,26 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2015 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef HYPERVISOR_TC_H_
+#define HYPERVISOR_TC_H_
+
+int hypervisor_tc_init(void);
+
+#endif /* !HYPERVISOR_TC_H_ */

--- a/src/marker.h
+++ b/src/marker.h
@@ -1,0 +1,54 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2015 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * marker — push packet-filter match signals to a UDP sink (the controller).
+ *
+ * When a `mark` packet filter (see packet_filter.c) matches a packet, it calls
+ * marker_emit(), which formats a one-line signal and sends a single UDP
+ * datagram to a configured sink (typically gns3server) — fire-and-forget, no
+ * listener, no thread. The sink address is set via the `marker sink` command
+ * or the UBRIDGE_MARKER_SINK env var at startup.
+ */
+
+#ifndef MARKER_H_
+#define MARKER_H_
+
+#include <stddef.h>
+
+/* Emit a marker signal for a matched filter. No-op when no sink is configured.
+ * Safe to call from the bridge relay (listener) threads. */
+void marker_emit(const char *filter_name, const char *tag, size_t len);
+
+/* Configure / clear the UDP sink (consumer = gns3server). 0 or -errno. */
+int  marker_set_sink(const char *host, int port);
+int  marker_clear_sink(void);
+void marker_set_node(const char *node_id);
+
+typedef struct {
+    int  enabled;            /* sink configured? */
+    char sink[72];           /* "host:port" for display, "" if unset */
+    char node[64];           /* node id echoed in signals, "" if unset */
+    unsigned long emitted;   /* signals sent since start */
+} marker_status_t;
+int  marker_status(marker_status_t *out);
+
+/* Hypervisor module registration (commands: sink/node/off/status). */
+int  hypervisor_marker_init(void);
+
+#endif /* !MARKER_H_ */

--- a/src/marker.h
+++ b/src/marker.h
@@ -32,8 +32,10 @@
 #include <stddef.h>
 
 /* Emit a marker signal for a matched filter. No-op when no sink is configured.
- * Safe to call from the bridge relay (listener) threads. */
-void marker_emit(const char *filter_name, const char *tag, size_t len);
+ * Safe to call from the bridge relay (listener) threads.
+ * `tag` and `link` are opaque ids echoed verbatim (NULL → "-" in the signal):
+ * `tag` for caller-side correlation, `link` for topology link attribution. */
+void marker_emit(const char *filter_name, const char *tag, const char *link, size_t len);
 
 /* Configure / clear the UDP sink (consumer = gns3server). 0 or -errno. */
 int  marker_set_sink(const char *host, int port);

--- a/src/packet_filter.c
+++ b/src/packet_filter.c
@@ -379,6 +379,96 @@ static void create_bpf_filter(packet_filter_t *filter)
 }
 
 /* ======================================================================== */
+/* MARK — passive tap: emit a marker signal on match, never drop (Linux)    */
+/* ======================================================================== */
+#ifdef __linux__
+#include "marker.h"
+
+struct mark_data {
+   struct bpf_program fp;
+   char *name;   /* filter name, captured at create time (handler never sees it) */
+   char *tag;    /* optional tag id, echoed in the signal */
+};
+
+/* Setup: argv[0] = bpf expr; optional argv[1]="tag", argv[2]=id */
+static int mark_setup(void **opt, int argc, char *argv[])
+{
+   struct mark_data *data = *opt;
+   pcap_t *pcap_dev;
+   char *filter;
+   int link_type;
+
+   if (argc != 1 && !(argc == 3 && !strcmp(argv[1], "tag")))
+      return (-1);
+
+   if (!data) {
+      if (!(data = malloc(sizeof(*data))))
+         return (-1);
+      memset(data, 0, sizeof(*data));
+      *opt = data;
+   }
+
+   filter = argv[0];
+   link_type = DLT_EN10MB;
+   pcap_dev = pcap_open_dead(link_type, 65535);
+   if (pcap_compile(pcap_dev, &data->fp, filter, 1, PCAP_NETMASK_UNKNOWN) < 0) {
+       fprintf(stderr, "Cannot compile mark filter '%s': %s\n", filter, pcap_geterr(pcap_dev));
+       return (-1);
+   }
+   pcap_close(pcap_dev);
+
+   if (argc == 3)
+      data->tag = strdup(argv[2]);
+   return (0);
+}
+
+/* Packet handler: emit a marker signal on match; always PASS (passive tap). */
+static int mark_handler(void *pkt, size_t len, void *opt)
+{
+   struct mark_data *data = opt;
+   struct pcap_pkthdr pkthdr;
+
+   memset(&pkthdr, 0, sizeof(pkthdr));
+   pkthdr.caplen = len;
+   pkthdr.len = len;
+   if (data != NULL) {
+       if (pcap_offline_filter(&data->fp, &pkthdr, pkt))
+          marker_emit(data->name, data->tag, len);
+   }
+   return (FILTER_ACTION_PASS);
+}
+
+static void mark_free(void **opt)
+{
+   if (*opt) {
+      struct mark_data *data = *opt;
+      pcap_freecode(&data->fp);
+      free(data->tag);
+      free(data->name);
+      free(*opt);
+      *opt = NULL;
+   }
+}
+
+static void create_mark_filter(packet_filter_t *filter)
+{
+    struct mark_data *data;
+
+    /* filter->name is strdup'd by add_packet_filter before create_filter runs,
+     * so capture it here (the handler only ever receives filter->data). */
+    if (!(data = malloc(sizeof(*data))))
+        return;
+    memset(data, 0, sizeof(*data));
+    data->name = filter->name ? strdup(filter->name) : NULL;
+    filter->data = data;
+    filter->type = FILTER_TYPE_MARK;
+    filter->setup = (void *)mark_setup;
+    filter->handler = (void *)mark_handler;
+    filter->free = (void *)mark_free;
+}
+#endif /* __linux__ */
+
+/* ======================================================================== */
 /* Generic functions for filter management                                  */
 /* ======================================================================== */
 
@@ -394,6 +484,9 @@ static filter_table_t lookup_table[] = {
     { "delay", create_delay_filter },
     { "corrupt", create_corrupt_filter },
     { "bpf", create_bpf_filter},
+#ifdef __linux__
+    { "mark", create_mark_filter },
+#endif
 };
 
 static int create_filter(packet_filter_t *filter, char *filter_type)

--- a/src/packet_filter.c
+++ b/src/packet_filter.c
@@ -389,11 +389,12 @@ struct mark_data {
    struct bpf_program fp;
    char *name;   /* filter name, captured at create time (handler never sees it) */
    char *tag;    /* optional tag id, echoed in the signal */
+   char *link;   /* optional link id, echoed in the signal for topology attribution */
    pcap_capture_t *cap;   /* optional: append matched packets to this pcap file */
 };
 
-/* Setup: argv[0] = bpf expr; optional keyword pairs "tag <id>" / "pcap <path>"
- * (any order, each at most once). */
+/* Setup: argv[0] = bpf expr; optional keyword pairs "tag <id>" / "link <id>" /
+ * "pcap <path>" (any order, each at most once). */
 static int mark_setup(void **opt, int argc, char *argv[])
 {
    struct mark_data *data = *opt;
@@ -421,11 +422,14 @@ static int mark_setup(void **opt, int argc, char *argv[])
    }
    pcap_close(pcap_dev);
 
-   /* optional keyword/value pairs: tag <id>, pcap <path> */
+   /* optional keyword/value pairs: tag <id>, link <id>, pcap <path> */
    for (i = 1; i + 1 < argc; i += 2) {
       if (!strcmp(argv[i], "tag")) {
          free(data->tag);
          data->tag = strdup(argv[i + 1]);
+      } else if (!strcmp(argv[i], "link")) {
+         free(data->link);
+         data->link = strdup(argv[i + 1]);
       } else if (!strcmp(argv[i], "pcap")) {
          if (data->cap)
             free_pcap_capture(data->cap);
@@ -455,7 +459,7 @@ static int mark_handler(void *pkt, size_t len, void *opt)
    pkthdr.len = len;
    if (data != NULL) {
        if (pcap_offline_filter(&data->fp, &pkthdr, pkt)) {
-          marker_emit(data->name, data->tag, len);
+          marker_emit(data->name, data->tag, data->link, len);
           if (data->cap)
              pcap_capture_packet(data->cap, pkt, len);
        }
@@ -469,6 +473,7 @@ static void mark_free(void **opt)
       struct mark_data *data = *opt;
       pcap_freecode(&data->fp);
       free(data->tag);
+      free(data->link);
       free(data->name);
       if (data->cap)
          free_pcap_capture(data->cap);

--- a/src/packet_filter.c
+++ b/src/packet_filter.c
@@ -383,22 +383,25 @@ static void create_bpf_filter(packet_filter_t *filter)
 /* ======================================================================== */
 #ifdef __linux__
 #include "marker.h"
+#include "pcap_capture.h"
 
 struct mark_data {
    struct bpf_program fp;
    char *name;   /* filter name, captured at create time (handler never sees it) */
    char *tag;    /* optional tag id, echoed in the signal */
+   pcap_capture_t *cap;   /* optional: append matched packets to this pcap file */
 };
 
-/* Setup: argv[0] = bpf expr; optional argv[1]="tag", argv[2]=id */
+/* Setup: argv[0] = bpf expr; optional keyword pairs "tag <id>" / "pcap <path>"
+ * (any order, each at most once). */
 static int mark_setup(void **opt, int argc, char *argv[])
 {
    struct mark_data *data = *opt;
    pcap_t *pcap_dev;
    char *filter;
-   int link_type;
+   int link_type, i;
 
-   if (argc != 1 && !(argc == 3 && !strcmp(argv[1], "tag")))
+   if (argc < 1)
       return (-1);
 
    if (!data) {
@@ -413,16 +416,35 @@ static int mark_setup(void **opt, int argc, char *argv[])
    pcap_dev = pcap_open_dead(link_type, 65535);
    if (pcap_compile(pcap_dev, &data->fp, filter, 1, PCAP_NETMASK_UNKNOWN) < 0) {
        fprintf(stderr, "Cannot compile mark filter '%s': %s\n", filter, pcap_geterr(pcap_dev));
+       pcap_close(pcap_dev);
        return (-1);
    }
    pcap_close(pcap_dev);
 
-   if (argc == 3)
-      data->tag = strdup(argv[2]);
+   /* optional keyword/value pairs: tag <id>, pcap <path> */
+   for (i = 1; i + 1 < argc; i += 2) {
+      if (!strcmp(argv[i], "tag")) {
+         free(data->tag);
+         data->tag = strdup(argv[i + 1]);
+      } else if (!strcmp(argv[i], "pcap")) {
+         if (data->cap)
+            free_pcap_capture(data->cap);
+         data->cap = create_pcap_capture(argv[i + 1], "EN10MB");
+         if (!data->cap) {
+            fprintf(stderr, "mark: cannot open pcap '%s'\n", argv[i + 1]);
+            return (-1);
+         }
+      } else {
+         return (-1);
+      }
+   }
+   if (i < argc)
+      return (-1);   /* dangling value without a keyword */
    return (0);
 }
 
-/* Packet handler: emit a marker signal on match; always PASS (passive tap). */
+/* Packet handler: on match, emit a marker signal and (optionally) append the
+ * packet to the pcap file; always PASS (passive tap). */
 static int mark_handler(void *pkt, size_t len, void *opt)
 {
    struct mark_data *data = opt;
@@ -432,8 +454,11 @@ static int mark_handler(void *pkt, size_t len, void *opt)
    pkthdr.caplen = len;
    pkthdr.len = len;
    if (data != NULL) {
-       if (pcap_offline_filter(&data->fp, &pkthdr, pkt))
+       if (pcap_offline_filter(&data->fp, &pkthdr, pkt)) {
           marker_emit(data->name, data->tag, len);
+          if (data->cap)
+             pcap_capture_packet(data->cap, pkt, len);
+       }
    }
    return (FILTER_ACTION_PASS);
 }
@@ -445,6 +470,8 @@ static void mark_free(void **opt)
       pcap_freecode(&data->fp);
       free(data->tag);
       free(data->name);
+      if (data->cap)
+         free_pcap_capture(data->cap);
       free(*opt);
       *opt = NULL;
    }

--- a/src/packet_filter.h
+++ b/src/packet_filter.h
@@ -30,6 +30,7 @@ enum {
     FILTER_TYPE_DELAY,
     FILTER_TYPE_CORRUPT,
     FILTER_TYPE_BPF,
+    FILTER_TYPE_MARK,
 };
 
 enum {

--- a/tests/capture/run_all.py
+++ b/tests/capture/run_all.py
@@ -1,0 +1,28 @@
+"""Run the whole capture test suite in sequence, exit non-zero if any fail."""
+import importlib
+import sys
+
+SUITES = [
+    "test_basic",
+]
+
+
+def main():
+    overall = 0
+    for name in SUITES:
+        print("\n" + "=" * 60)
+        print(name)
+        print("=" * 60)
+        mod = importlib.import_module(name)
+        rc = mod.main()
+        if rc != 0:
+            overall = rc
+    print("\n" + "=" * 60)
+    print("ALL SUITES: " + ("PASS" if overall == 0 else "FAIL"))
+    print("=" * 60)
+    return overall
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, __file__[: -len("run_all.py")])
+    raise SystemExit(main())

--- a/tests/capture/test_basic.py
+++ b/tests/capture/test_basic.py
@@ -1,0 +1,91 @@
+"""Basic regression for the capture module (kernel-side AF_PACKET capture).
+
+Captures frames on one end of a veth pair while ping generates traffic, then
+confirms the pcap file is written and non-empty. Also covers the
+start/stop lifecycle and error paths. Stdlib only. Requires CAP_NET_ADMIN —
+run under sudo.
+
+Reuses Ubridge / Results from tests/brctl/common.py.
+"""
+import os
+import sys
+import subprocess
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "brctl"))
+from common import Ubridge, Results  # noqa: E402
+
+PREFIX = "ubcap-"
+PORT = 13041
+VETH_A = PREFIX + "a"
+VETH_B = PREFIX + "b"
+PCAP = "/tmp/%s.pcap" % PREFIX.rstrip("-")
+
+
+def _ip(args):
+    return subprocess.run(["ip"] + args, capture_output=True, text=True)
+
+
+def _exists(name):
+    return _ip(["-o", "link", "show", name]).returncode == 0
+
+
+def main():
+    r = Results()
+
+    if os.path.exists(PCAP):
+        os.remove(PCAP)
+
+    try:
+        with Ubridge(port=PORT) as ub:
+            c = ub.connect()
+            try:
+                # veth pair + IPs to generate real frames between the ends
+                r.check("link veth pair", c.code("link veth %s %s" % (VETH_A, VETH_B)) == "100")
+                c.code("link addr %s 10.99.0.1/24" % VETH_A)
+                c.code("link addr %s 10.99.0.2/24" % VETH_B)
+                c.code("link set %s up" % VETH_A)
+                c.code("link set %s up" % VETH_B)
+
+                # start capturing on VETH_A
+                res = c.send("capture start_kernel %s %s" % (VETH_A, PCAP))
+                r.check("start_kernel", res.startswith("100-"), res)
+
+                # double start is rejected
+                r.check("double start -> 209", c.code("capture start_kernel %s %s" % (VETH_A, PCAP)) == "209")
+
+                # generate traffic (ARP + ICMP) between the two ends
+                subprocess.run(["ping", "-c", "3", "-W", "1", "-I", VETH_A, "10.99.0.2"],
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                time.sleep(0.3)  # let the last frames drain into the pcap
+
+                # stop
+                r.check("stop_kernel", c.code("capture stop_kernel") == "100")
+
+                # the pcap file must exist and contain more than just its header
+                r.check("pcap file created", os.path.exists(PCAP))
+                if os.path.exists(PCAP):
+                    size = os.path.getsize(PCAP)
+                    r.check("pcap captured packets (size>24)", size > 24, "size=%d" % size)
+
+                # idempotent stop (no active capture) is OK
+                r.check("stop again -> 100 (idempotent)", c.code("capture stop_kernel") == "100")
+
+                # error paths
+                r.check("start on missing iface -> 208",
+                        c.code("capture start_kernel %s-nope %s" % (VETH_A, PCAP)) == "208")
+            finally:
+                c.send("capture stop_kernel")
+                c.close()
+    finally:
+        # cleanup veth (deleting one end removes the pair) + pcap
+        if _exists(VETH_A):
+            _ip(["link", "del", VETH_A])
+        if os.path.exists(PCAP):
+            os.remove(PCAP)
+
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/marker/run_all.py
+++ b/tests/marker/run_all.py
@@ -1,0 +1,28 @@
+"""Run the whole marker test suite in sequence, exit non-zero if any fail."""
+import importlib
+import sys
+
+SUITES = [
+    "test_basic",
+]
+
+
+def main():
+    overall = 0
+    for name in SUITES:
+        print("\n" + "=" * 60)
+        print(name)
+        print("=" * 60)
+        mod = importlib.import_module(name)
+        rc = mod.main()
+        if rc != 0:
+            overall = rc
+    print("\n" + "=" * 60)
+    print("ALL SUITES: " + ("PASS" if overall == 0 else "FAIL"))
+    print("=" * 60)
+    return overall
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, __file__[: -len("run_all.py")])
+    raise SystemExit(main())

--- a/tests/marker/test_basic.py
+++ b/tests/marker/test_basic.py
@@ -60,7 +60,7 @@ def main():
                 c.send("bridge add_nio_udp br0 %d 127.0.0.1 %d" % (la, ra))   # NIO-A
                 c.send("bridge add_nio_udp br0 %d 127.0.0.1 %d" % (lb, rb))   # NIO-B
                 r.check("add mark filter",
-                        c.send("bridge add_packet_filter br0 f1 mark ip tag 7").startswith("100-"))
+                        c.send("bridge add_packet_filter br0 f1 mark ip tag 7 link 9").startswith("100-"))
                 r.check("bridge start", c.send("bridge start br0").startswith("100-"))
 
                 # inject an IP frame into NIO-A's listen port
@@ -72,8 +72,8 @@ def main():
                     data, _ = ms.recvfrom(4096)
                     sig = data.decode(errors="replace")
                     r.check("marker signal received", sig.startswith("MARK "), sig.strip())
-                    r.check("signal node/filter/tag", all(x in sig for x in
-                            ("node=testnode", "filter=f1", "tag=7")), sig.strip())
+                    r.check("signal node/filter/link/tag", all(x in sig for x in
+                            ("node=testnode", "filter=f1", "link=9", "tag=7")), sig.strip())
                     r.check("signal len", ("len=%d" % len(frame)) in sig, sig.strip())
                 except socket.timeout:
                     r.check("marker signal received", False, "timeout")
@@ -95,6 +95,9 @@ def main():
                 except socket.timeout:
                     r.check("no signal after marker off", True)
 
+                # done with f1; drop it so later checks see a known filter set
+                c.send("bridge delete_packet_filter br0 f1")
+
                 # mark filter with pcap: matched packets are appended to a pcap
                 PCAP = "/tmp/ubmark_test.pcap"
                 if os.path.exists(PCAP):
@@ -113,6 +116,21 @@ def main():
                             "size=%d" % len(blob))
                 if os.path.exists(PCAP):
                     os.remove(PCAP)
+
+                # link/tag omitted -> signal carries link=- and tag=- (the default
+                # for absent opaque fields); marker was turned off above, re-enable
+                c.send("marker sink 127.0.0.1 %d" % marker_port)
+                r.check("add mark filter (no link)",
+                        c.send("bridge add_packet_filter br0 f3 mark ip").startswith("100-"))
+                inj.sendto(frame, ("127.0.0.1", la))
+                time.sleep(0.3)
+                try:
+                    data, _ = ms.recvfrom(4096)
+                    sig2 = data.decode(errors="replace")
+                    r.check("signal link=- when omitted",
+                            ("link=-" in sig2 and "tag=-" in sig2), sig2.strip())
+                except socket.timeout:
+                    r.check("signal link=- when omitted", False, "timeout")
 
                 # status reports an emitted count
                 st = c.send("marker status")

--- a/tests/marker/test_basic.py
+++ b/tests/marker/test_basic.py
@@ -1,0 +1,113 @@
+"""Basic regression for the marker feature (mark filter + UDP signal push).
+
+A `mark` packet filter signals matches by pushing a UDP datagram to a
+configured sink (gns3server). This test stands up a UDP listener as the sink,
+injects an IP frame into a UDP-NIO bridge, and asserts the signal arrives and
+the frame is still relayed (passive tap). Pure user-space (UDP + libpcap cBPF)
+— no CAP_NET_ADMIN needed, no sudo. Uses the in-repo ./ubridge (the installed
+binary may lack the marker module).
+"""
+import os
+import sys
+import socket
+import struct
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "brctl"))
+from common import Ubridge, Results  # noqa: E402
+
+PORT = 13060
+REPO_UBRIDGE = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "ubridge"))
+
+
+def _free_udp():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _ip_frame():
+    """Minimal Ethernet + IPv4 frame (matches BPF `ip`)."""
+    eth = b"\xff\xff\xff\xff\xff\xff\x00\x11\x22\x33\x44\x55" + struct.pack("!H", 0x0800)
+    ip = struct.pack("!BBHHHBBH4s4s", 0x45, 0, 20, 0x1234, 0, 64, 17, 0,
+                     bytes([10, 0, 0, 1]), bytes([10, 0, 0, 2]))
+    return eth + ip
+
+
+def main():
+    r = Results()
+    marker_port = _free_udp()
+    la, lb = _free_udp(), _free_udp()      # NIO listen ports (ubridge binds these)
+    ra, rb = _free_udp(), _free_udp()      # NIO remote ports (listeners here)
+
+    ms = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); ms.settimeout(2.0); ms.bind(("127.0.0.1", marker_port))
+    rbs = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); rbs.settimeout(2.0); rbs.bind(("127.0.0.1", rb))
+    # nio_udp connect()s to the remote, so it only accepts packets whose source
+    # is the configured remote — bind the injector to NIO-A's remote port (ra).
+    inj = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    inj.bind(("127.0.0.1", ra))
+
+    frame = _ip_frame()
+    try:
+        with Ubridge(port=PORT, binary=REPO_UBRIDGE) as ub:
+            c = ub.connect()
+            try:
+                c.send("marker sink 127.0.0.1 %d" % marker_port)
+                c.send("marker node testnode")
+                c.send("bridge create br0")
+                c.send("bridge add_nio_udp br0 %d 127.0.0.1 %d" % (la, ra))   # NIO-A
+                c.send("bridge add_nio_udp br0 %d 127.0.0.1 %d" % (lb, rb))   # NIO-B
+                r.check("add mark filter",
+                        c.send("bridge add_packet_filter br0 f1 mark ip tag 7").startswith("100-"))
+                r.check("bridge start", c.send("bridge start br0").startswith("100-"))
+
+                # inject an IP frame into NIO-A's listen port
+                inj.sendto(frame, ("127.0.0.1", la))
+                time.sleep(0.3)
+
+                # marker signal arrived at the sink?
+                try:
+                    data, _ = ms.recvfrom(4096)
+                    sig = data.decode(errors="replace")
+                    r.check("marker signal received", sig.startswith("MARK "), sig.strip())
+                    r.check("signal node/filter/tag", all(x in sig for x in
+                            ("node=testnode", "filter=f1", "tag=7")), sig.strip())
+                    r.check("signal len", ("len=%d" % len(frame)) in sig, sig.strip())
+                except socket.timeout:
+                    r.check("marker signal received", False, "timeout")
+
+                # passive: the frame was still relayed to NIO-B's remote
+                try:
+                    rel, _ = rbs.recvfrom(4096)
+                    r.check("frame relayed (passive)", rel == frame, "len=%d" % len(rel))
+                except socket.timeout:
+                    r.check("frame relayed (passive)", False, "timeout")
+
+                # marker off -> no more signals
+                c.send("marker off")
+                inj.sendto(frame, ("127.0.0.1", la))
+                time.sleep(0.3)
+                try:
+                    ms.recvfrom(4096)
+                    r.check("no signal after marker off", False, "got signal after off")
+                except socket.timeout:
+                    r.check("no signal after marker off", True)
+
+                # status reports an emitted count
+                st = c.send("marker status")
+                r.check("status reports emitted", "emitted=" in st, st.replace("\n", " | "))
+            finally:
+                c.send("bridge stop br0")
+                c.send("bridge delete br0")
+                c.close()
+    finally:
+        for s in (ms, rbs, inj):
+            s.close()
+
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/marker/test_basic.py
+++ b/tests/marker/test_basic.py
@@ -95,6 +95,25 @@ def main():
                 except socket.timeout:
                     r.check("no signal after marker off", True)
 
+                # mark filter with pcap: matched packets are appended to a pcap
+                PCAP = "/tmp/ubmark_test.pcap"
+                if os.path.exists(PCAP):
+                    os.remove(PCAP)
+                r.check("add mark+pcap filter",
+                        c.send("bridge add_packet_filter br0 f2 mark ip pcap %s" % PCAP).startswith("100-"))
+                inj.sendto(frame, ("127.0.0.1", la))
+                time.sleep(0.3)
+                c.send("bridge delete_packet_filter br0 f2")   # closes/flushes the pcap
+                time.sleep(0.1)
+                r.check("pcap file created", os.path.exists(PCAP))
+                if os.path.exists(PCAP):
+                    blob = open(PCAP, "rb").read()
+                    # 24B global header + 16B record header + frame bytes; frame must be present
+                    r.check("pcap captured the frame", frame in blob and len(blob) > 24 + 16,
+                            "size=%d" % len(blob))
+                if os.path.exists(PCAP):
+                    os.remove(PCAP)
+
                 # status reports an emitted count
                 st = c.send("marker status")
                 r.check("status reports emitted", "emitted=" in st, st.replace("\n", " | "))

--- a/tests/tap/run_all.py
+++ b/tests/tap/run_all.py
@@ -1,0 +1,28 @@
+"""Run the whole tap test suite in sequence, exit non-zero if any fail."""
+import importlib
+import sys
+
+SUITES = [
+    "test_basic",
+]
+
+
+def main():
+    overall = 0
+    for name in SUITES:
+        print("\n" + "=" * 60)
+        print(name)
+        print("=" * 60)
+        mod = importlib.import_module(name)
+        rc = mod.main()
+        if rc != 0:
+            overall = rc
+    print("\n" + "=" * 60)
+    print("ALL SUITES: " + ("PASS" if overall == 0 else "FAIL"))
+    print("=" * 60)
+    return overall
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, __file__[: -len("run_all.py")])
+    raise SystemExit(main())

--- a/tests/tap/test_basic.py
+++ b/tests/tap/test_basic.py
@@ -1,0 +1,97 @@
+"""Basic lifecycle + error-path regression for the tap module.
+
+Covers persistent-TAP create / set_owner / delete, common error paths
+(duplicate create, missing delete, overlong name, bad uid), and the brctl
+integration that wires a persistent TAP into a kernel bridge. Stdlib only —
+no third-party dependencies. Requires CAP_NET_ADMIN, so run under sudo.
+
+Reuses Ubridge / Client / Results from tests/brctl/common.py.
+"""
+import os
+import sys
+import subprocess
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "brctl"))
+from common import Ubridge, Results  # noqa: E402
+
+PREFIX = "ubtapt-"
+PORT = 13030
+OWNER_UID = "1000"  # representative non-root uid for the set_owner check
+
+
+def _ip(args):
+    return subprocess.run(["ip"] + args, capture_output=True, text=True)
+
+
+def _exists(name):
+    return _ip(["-o", "link", "show", name]).returncode == 0
+
+
+def _no_residual():
+    """True if no tuntap device whose name starts with PREFIX remains."""
+    out = _ip(["-o", "tuntap", "show"]).stdout
+    return not any(PREFIX in line for line in out.splitlines())
+
+
+def _force_delete(name):
+    """Best-effort kernel-side cleanup if a test leaves a tap behind."""
+    _ip(["tuntap", "del", "mode", "tap", "dev", name])
+
+
+def main():
+    r = Results()
+    t0 = PREFIX + "t0"
+    t1 = PREFIX + "t1"
+    br = PREFIX + "br0"
+
+    with Ubridge(port=PORT) as ub:
+        c = ub.connect()
+        try:
+            # --- lifecycle ---
+            r.check("create t0", c.code("tap create %s" % t0) == "100")
+            r.check("kernel sees t0", _exists(t0))
+            r.check("dup create -> 206/EBUSY",
+                    c.code("tap create %s" % t0) == "206",
+                    c.send("tap create %s" % t0))
+            r.check("overlong name -> 204",
+                    c.code("tap create %s" % ("x" * 16)) == "204")
+            r.check("set_owner ok",
+                    c.code("tap set_owner %s %s" % (t0, OWNER_UID)) == "100")
+            r.check("set_owner bad uid -> 204",
+                    c.code("tap set_owner %s abc" % t0) == "204")
+            r.check("set_owner on missing tap -> 206",
+                    c.code("tap set_owner %s-nope %s" % (t0, OWNER_UID)) == "206")
+            r.check("delete t0", c.code("tap delete %s" % t0) == "100")
+            r.check("kernel t0 gone", not _exists(t0))
+            r.check("delete again -> 207/ENODEV",
+                    c.code("tap delete %s" % t0) == "207")
+
+            # --- brctl integration: persistent TAP enslaved to a kernel bridge ---
+            r.check("create t1", c.code("tap create %s" % t1) == "100")
+            r.check("brctl create br0", c.code("brctl create %s" % br) == "100")
+            r.check("brctl addif br0 t1",
+                    c.code("brctl addif %s %s" % (br, t1)) == "100",
+                    c.send("brctl addif %s %s" % (br, t1)))
+            # the tap should now be a port of the bridge in the kernel
+            link = _ip(["-d", "link", "show", t1]).stdout
+            r.check("kernel: t1 enslaved to br0", br in link and "master" in link, link.strip()[:80])
+        finally:
+            # --- cleanup (tolerant) ---
+            c.send("brctl delif %s %s" % (br, t1))
+            c.send("brctl delete %s" % br)
+            c.send("tap delete %s" % t1)
+            c.send("tap delete %s" % t0)
+            c.close()
+            for name in (t0, t1):
+                if _exists(name):
+                    _force_delete(name)
+            if _exists(br):
+                _ip(["link", "del", br])
+
+        r.check("no residual taps", _no_residual())
+
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tc/run_all.py
+++ b/tests/tc/run_all.py
@@ -1,0 +1,28 @@
+"""Run the whole tc test suite in sequence, exit non-zero if any fail."""
+import importlib
+import sys
+
+SUITES = [
+    "test_basic",
+]
+
+
+def main():
+    overall = 0
+    for name in SUITES:
+        print("\n" + "=" * 60)
+        print(name)
+        print("=" * 60)
+        mod = importlib.import_module(name)
+        rc = mod.main()
+        if rc != 0:
+            overall = rc
+    print("\n" + "=" * 60)
+    print("ALL SUITES: " + ("PASS" if overall == 0 else "FAIL"))
+    print("=" * 60)
+    return overall
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, __file__[: -len("run_all.py")])
+    raise SystemExit(main())

--- a/tests/tc/test_basic.py
+++ b/tests/tc/test_basic.py
@@ -1,0 +1,90 @@
+"""Basic regression for the tc module (kernel netem qdisc).
+
+Attaches netem (delay/jitter/loss/dup) to a throwaway dummy interface and
+reads it back with `tc qdisc show` to confirm the netlink ABI and unit
+conversions are correct. Stdlib only. Requires CAP_NET_ADMIN — run under sudo.
+
+Reuses Ubridge / Results from tests/brctl/common.py.
+"""
+import os
+import sys
+import subprocess
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "brctl"))
+from common import Ubridge, Results  # noqa: E402
+
+PREFIX = "ubtc-"
+PORT = 13040
+IFC = PREFIX + "dummy0"
+
+
+def _ip(args):
+    return subprocess.run(["ip"] + args, capture_output=True, text=True)
+
+
+def _tc(args):
+    return subprocess.run(["tc"] + args, capture_output=True, text=True)
+
+
+def _qdisc(ifname):
+    return _tc(["qdisc", "show", "dev", ifname]).stdout
+
+
+def main():
+    r = Results()
+
+    # throwaway dummy interface to hang the qdisc on
+    _ip(["link", "add", IFC, "type", "dummy"])
+    _ip(["link", "set", IFC, "up"])
+
+    try:
+        with Ubridge(port=PORT) as ub:
+            c = ub.connect()
+            try:
+                # --- netem set: delay + loss, read back from the kernel ---
+                res = c.send("tc netem set %s delay 100 loss 50" % IFC)
+                r.check("netem set delay+loss", res.startswith("100-"), res)
+                q = _qdisc(IFC)
+                r.check("kernel: netem attached", "netem" in q, q.strip()[:120])
+                r.check("kernel: delay applied", "delay" in q, q.strip()[:120])
+                r.check("kernel: loss applied", "loss" in q, q.strip()[:120])
+
+                # --- netem set: delay + jitter + dup ---
+                r.check("netem set jitter+dup",
+                        c.send("tc netem set %s delay 50 jitter 10 dup 20" % IFC).startswith("100-"))
+                q = _qdisc(IFC)
+                # tc prints jitter as a bare value after delay: "delay 50ms 10ms"
+                # (not the word "jitter"), so assert the jitter value is present.
+                r.check("kernel: jitter applied", "10ms" in q, q.strip()[:120])
+
+                # --- reset removes the qdisc ---
+                r.check("reset", c.send("tc reset %s" % IFC).startswith("100-"))
+                r.check("kernel: netem gone after reset", "netem" not in _qdisc(IFC))
+
+                # --- error paths ---
+                r.check("netem missing iface -> 206",
+                        c.send("tc netem set %s-nope delay 10" % PREFIX).startswith("206-"))
+                r.check("netem too few params -> 203",
+                        c.send("tc netem set %s" % IFC).startswith("203-"))
+                r.check("netem negative delay -> 204",
+                        c.send("tc netem set %s delay -5" % IFC).startswith("204-"))
+                r.check("netem bad keyword -> 204",
+                        c.send("tc netem set %s bogus 5" % IFC).startswith("204-"))
+                r.check("netem loss out of range -> 204",
+                        c.send("tc netem set %s loss 150" % IFC).startswith("204-"))
+                r.check("netem bad delay value -> 204",
+                        c.send("tc netem set %s delay abc" % IFC).startswith("204-"))
+                r.check("reset missing iface -> 207",
+                        c.send("tc reset %s-nope" % PREFIX).startswith("207-"))
+            finally:
+                # leave the interface clean
+                c.send("tc reset %s" % IFC)
+                c.close()
+    finally:
+        _ip(["link", "del", IFC])
+
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tc/test_basic.py
+++ b/tests/tc/test_basic.py
@@ -57,6 +57,11 @@ def main():
                 # (not the word "jitter"), so assert the jitter value is present.
                 r.check("kernel: jitter applied", "10ms" in q, q.strip()[:120])
 
+                # --- netem set: corrupt ---
+                r.check("netem set corrupt",
+                        c.send("tc netem set %s corrupt 30" % IFC).startswith("100-"))
+                r.check("kernel: corrupt applied", "corrupt 30%" in _qdisc(IFC), _qdisc(IFC).strip()[:120])
+
                 # --- reset removes the qdisc ---
                 r.check("reset", c.send("tc reset %s" % IFC).startswith("100-"))
                 r.check("kernel: netem gone after reset", "netem" not in _qdisc(IFC))


### PR DESCRIPTION
## Summary

Adds the missing kernel-side pieces for the **kernel data plane** model, where frames flow `persistent TAP → kernel bridge (brctl) → TAP` entirely in-kernel and never reach ubridge's user-space NIO relay. Once traffic bypasses the relay, user-space packet filters and NIO-level capture can no longer see it — so impairment, capture, and match signaling must also live in the kernel (or tap the interface directly). This PR provides those pieces, plus a controller-facing match-signaling channel.

All new modules are **Linux-only** (`#ifdef __linux__` + the Makefile Linux block) and are exposed over the existing hypervisor text protocol as `<module> <command> [args...]`. ubridge remains inert until commanded.

## What's added

| Module | File(s) | Purpose |
|--------|---------|---------|
| `tap` | `hypervisor_tap.{c,h}` | Persistent TAP lifecycle: `create` / `set_owner` / `delete` via `/dev/net/tun` ioctls. A persistent TAP survives its creating fd, so an unprivileged QEMU can open it later once ownership is handed over. |
| `tc` | `hypervisor_tc.{c,h}` | Kernel netem link impairment: `tc netem set <if> [delay/jitter/loss/dup/corrupt]` and `tc reset <if>` via netlink — the qdisc-level replacement for the user-space `delay`/`packet_loss`/`corrupt` filters. |
| `capture` | `hypervisor_capture.{c,h}` | Kernel-side `AF_PACKET` capture into a pcap: `capture start_kernel <if> <pcap> [dlt]` / `capture stop_kernel`. Singleton; reuses the existing pcap writer. |
| `marker` | `hypervisor_marker.c`, `marker.h` | Pushes packet-filter match signals to a UDP sink (gns3server): `marker sink/node/off/status`, also injectable via `UBRIDGE_MARKER_SINK` / `UBRIDGE_MARKER_NODE` env vars. |

Plus a new **`mark` packet filter** (`packet_filter.c`, under `bridge add_packet_filter … mark`): a **passive tap** that, on a libpcap cBPF match, emits a marker signal and optionally appends the matched packet to a pcap — it never drops (use the existing `bpf` filter to drop). Supports `tag <id>`, `link <id>` (per-link attribution when one bridge serves several links, e.g. IOU), and `pcap <path>` (filtered capture), in any order.

`hypervisor.c` and `Makefile` wire the new modules in (registration order is documented in the README `module_list` example).

## Signal format

One UDP datagram per match:
```
MARK <sec.usec> node=<id> filter=<name> link=<link> tag=<tag> len=<n>
```
`node`/`link`/`tag` are `-` when unset. Metadata only — no packet bytes (`len` is the size; bytes go to the optional pcap).

## Privileges

`tap`/`tc` require `CAP_NET_ADMIN`; `capture` requires `CAP_NET_RAW` — both granted by the existing `sudo make install` (`cap_net_admin,cap_net_raw=ep`). The `marker` engine + `mark` filter are pure user-space (UDP + libpcap cBPF) and need neither. Clients (gns3server) need no privileges or `/dev/net/tun` access — they talk to ubridge over TCP.

## Documentation

- Per-module docs: [`doc/tap.md`](https://github.com/yueguobin/ubridge/blob/feature/kernel-dataplane/doc/tap.md), `doc/tc.md`, `doc/capture.md`, `doc/marker.md`
- Cross-cutting gns3server contract: `doc/gns3server-integration.md`
- `README.md` module list and a `mark` entry in the Filter types section refreshed

## Testing

Stdlib-only Python suites under `tests/{tap,tc,capture,marker}/` (each with `run_all.py`). They require `CAP_NET_ADMIN`/`CAP_NET_RAW` (create interfaces / attach qdiscs), run under sudo after `sudo make install`:

```bash
cd tests/tap     && sudo python3 run_all.py    # lifecycle + error paths
cd tests/tc      && sudo python3 run_all.py    # netem delay/jitter/loss/dup/corrupt + reset (17 checks)
cd tests/capture && sudo python3 run_all.py    # AF_PACKET capture lifecycle + error paths
cd tests/marker  && python3 run_all.py         # pure user-space, no sudo (signal + passive relay + off)
```

All suites pass on the reference kernel (Linux 6.x, x86_64) with a capabilities-equipped binary.
