### PR TITLE
brctl: per-port VLAN membership (vlan_add / vlan_del / vlan_show) + QinQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,12 +606,13 @@ These commands modify bridge port attributes via the kernel's
 IFLA_PROTINFO interface. The port interface must already be
 enslaved to the bridge.
 
-- **brctl setportprio** *\<bridge_name\>* *\<port\>* *\<0-255\>*:
-    Set the STP port priority.
+- **brctl setportprio** *\<bridge_name\>* *\<port\>* *\<0-63\>*:
+    Set the STP port priority (kernel limit; the parser accepts 0-255
+    but 64+ is rejected by the kernel with 206).
 
 ``` {.bash}
-brctl setportprio br0 tap0 128
-100-Port priority 128 set on tap0
+brctl setportprio br0 tap0 48
+100-Port priority 48 set on tap0
 ```
 
 - **brctl setpathcost** *\<bridge_name\>* *\<port\>* *\<1-65535\>*:
@@ -647,6 +648,42 @@ brctl hairpin br0 tap0 on
 ``` {.bash}
 brctl isolated br0 tap0 on
 100-Port isolation enabled on tap0
+```
+
+#### VLAN membership
+
+Per-port VLAN ID add/delete/show — the primitives for access/trunk/QinQ
+port modes. The bridge must have `vlanfiltering on`, and the port must be
+enslaved to it. ESW access/trunk modes are composed from these primitives
+in gns3server, not here.
+
+- **brctl vlan_add** *\<bridge_name\>* *\<port\>* *\<vid\>* `[vid <end>]` `[pvid]` `[untagged]`:
+    Add a VLAN (or `vid <end>` range) to a port. `pvid` = strip the tag on
+    ingress (the port's PVID); `untagged` = strip on egress.
+
+``` {.bash}
+brctl vlan_add br0 tap0 100 pvid untagged
+100-VLAN 100 added on tap0
+```
+
+- **brctl vlan_del** *\<bridge_name\>* *\<port\>* *\<vid\>* `[vid <end>]`:
+    Delete a VLAN/range from a port (by VID only — flags are not accepted).
+
+``` {.bash}
+brctl vlan_del br0 tap0 100
+100-VLAN 100 deleted from tap0
+```
+
+- **brctl vlan_show** *\<bridge_name\>* `[<port>]`:
+    List per-port VLAN membership — one continuation line per (port, vid)
+    as `<port> <vid> [PVID] [Egress Untagged]`, then a `100-` summary.
+
+``` {.bash}
+brctl vlan_show br0 tap0
+101 tap0 1 Egress Untagged
+101 tap0 100 PVID Egress Untagged
+101 tap0 200
+100-3 VLAN entries
 ```
 
 

--- a/doc/brctl.md
+++ b/doc/brctl.md
@@ -107,11 +107,15 @@ VLANs ride in `IFLA_AF_SPEC` (the `AF_BRIDGE` sibling of `IFLA_PROTINFO`), as
 iproute2 `bridge vlan add|del` sends them: `add` maps to the kernel's
 `br_setlink`, `del` to `br_dellink`. The port must be enslaved to the bridge,
 and the bridge must have `vlanfiltering on` (else the kernel rejects with
-`-EINVAL`). `BRIDGE_FLAGS_SELF` makes the op target the port itself.
+`-EINVAL`). No `IFLA_BRIDGE_FLAGS` is sent — an unset flags field routes the
+op through the MASTER path (`br_setlink`), like iproute2 with no
+`self`/`master`; sending `BRIDGE_FLAGS_SELF` would instead target the port's
+own `ndo_bridge_setlink` and fail with `-EOPNOTSUPP` on plain (non-switchdev)
+ports.
 
 | Command | Args | Description |
 |---------|------|-------------|
-| `vlan_add <bridge> <port> <vid> [vid <end>] [pvid] [untagged]` | 3–7 | Add a VID (or `vid <end>` range). `pvid` = strip tag on ingress (sets the port PVID); `untagged` = strip on egress. A range is encoded as `RANGE_BEGIN`/`RANGE_END`. Duplicate VID → `EEXIST` (206). |
+| `vlan_add <bridge> <port> <vid> [vid <end>] [pvid] [untagged]` | 3–7 | Add a VID (or `vid <end>` range). `pvid` = strip tag on ingress (sets the port PVID); `untagged` = strip on egress. A range is encoded as `RANGE_BEGIN`/`RANGE_END`. Re-adding a VID is idempotent (success; flags are updated if they differ). |
 | `vlan_del <bridge> <port> <vid> [vid <end>]` | 3–5 | Delete a VID/range. Flags are rejected — deletion is by VID only. |
 
 VIDs are 1–4094 (4095 reserved); an out-of-range or reversed range → `204`.
@@ -161,7 +165,7 @@ of `vlan_add` (ranges), with the native VLAN added `pvid untagged`.
 
 ## Testing
 
-Tested on **Linux 6.19.11-1-default** (x86_64), ubridge with
+Tested on **Linux 7.1.2-1-default** (x86_64), ubridge with
 `cap_net_admin,cap_net_raw=ep`. Kernel-side state was verified with
 `ip -d link show <bridge>` and `ip -d link show <port>` (the `bridge_slave`
 attributes appear on the port).
@@ -206,7 +210,7 @@ Eight suites (151 tests in total):
 | `test_no_privs` | 4 | No-cap binary rejects mutations, survives gracefully |
 | `test_vlan` | 24 | Per-port VLAN add/del/range, kernel-side verification, error paths |
 
-All 151 tests pass on the reference kernel (6.19.11-1-default).
+All 151 tests pass on the reference kernel (7.1.2-1-default).
 
 ### Kernel verification reference
 
@@ -229,5 +233,5 @@ VLAN membership is verified with `bridge vlan show dev <port>` instead:
 |---------------|----------------------------------------------|
 | `vlan_add <br> <p> 100 pvid untagged` | `100 PVID Egress Untagged` |
 | `vlan_add <br> <p> 200` | `200` |
-| `vlan_add <br> <p> 300 vid 302` | `300-302` |
+| `vlan_add <br> <p> 300 vid 302` | `300`, `301`, `302` (per-VID lines; `300-302` only with `bridge -compressed vlan show`) |
 | `vlan_del <br> <p> 200` | `200` row gone |

--- a/doc/brctl.md
+++ b/doc/brctl.md
@@ -126,6 +126,24 @@ not here): access VLAN *N* = `vlanfiltering on` → `vlan_del <port> 1` →
 `vlan_add <br> <port> N pvid untagged`; a dot1q trunk's tagged list is a series
 of `vlan_add` (ranges), with the native VLAN added `pvid untagged`.
 
+## Limitations
+
+- **Default PVID 1 is not auto-cleaned.** A port freshly enslaved to a
+  `vlanfiltering` bridge inherits the default PVID 1 (PVID + Egress Untagged).
+  Configuring an access or trunk port therefore needs an explicit
+  `vlan_del <bridge> <port> 1` first — `vlan_add ... pvid` moves the PVID but
+  leaves VID 1 as a plain member. This matches iproute2 (`bridge vlan add ...
+  pvid` likewise does not remove VID 1); compose the full sequence at the caller.
+- **QinQ is outer-tag (provider-bridge) only.** With `setvlanproto 0x88a8` the
+  bridge filters on the outer S-tag (0x88a8) and carries the inner C-tag
+  (0x8100) through transparently — standard Linux provider-bridge QinQ. It does
+  **not** do selective QinQ (classification/mapping on the inner VLAN); that
+  would require `IFLA_BRIDGE_VLAN_TUNNEL_INFO`, which is not implemented.
+- **No MAC (FDB) table read/flush.** There is no `fdb_show` / `fdb_flush`. The
+  kernel bridge learns and ages MAC entries itself; ubridge has never exposed
+  mac-table access and gns3-server does not consume it, so it was deliberately
+  omitted. Inspect with the external `bridge fdb show dev <port>` if needed.
+
 ## Implementation notes
 
 - **netlink library** — `src/netlink/nl.c` (lxc-derived). Helpers used:

--- a/doc/brctl.md
+++ b/doc/brctl.md
@@ -117,7 +117,7 @@ ports.
 |---------|------|-------------|
 | `vlan_add <bridge> <port> <vid> [vid <end>] [pvid] [untagged]` | 3–7 | Add a VID (or `vid <end>` range). `pvid` = strip tag on ingress (sets the port PVID); `untagged` = strip on egress. A range is encoded as `RANGE_BEGIN`/`RANGE_END`. Re-adding a VID is idempotent (success; flags are updated if they differ). |
 | `vlan_del <bridge> <port> <vid> [vid <end>]` | 3–5 | Delete a VID/range. Flags are rejected — deletion is by VID only. |
-| `vlan_show <bridge> [port]` | 1–2 | List per-port VID membership (`RTM_GETLINK` AF_BRIDGE dump + `IFLA_EXT_MASK=RTEXT_FILTER_BRVLAN`). One line per (port, vid): `<port> <vid> [PVID] [Egress Untagged]`. |
+| `vlan_show <bridge> [port]` | 1–2 | List per-port VID membership (`RTM_GETLINK` AF_BRIDGE dump, compressed — `RTEXT_FILTER_BRVLAN_COMPRESSED` — so a port with thousands of VIDs fits the kernel's ~32 KiB datagram cap; ranges are expanded back to one line per vid). Line format: `<port> <vid> [PVID] [Egress Untagged]`. |
 
 VIDs are 1–4094 (4095 reserved); an out-of-range or reversed range → `204`.
 
@@ -163,6 +163,8 @@ of `vlan_add` (ranges), with the native VLAN added `pvid untagged`.
 | `realloc` failure in `br_dump_addresses` jumped to the success path | Partial address list returned as a complete dump under memory pressure | `ret = -1; goto out` on realloc failure |
 | `netlink_open` returned `-errno` without closing the socket after `setsockopt` / `bind` / `getsockname` failed | fd leak on (rare) open-time failure paths | `goto err` closes the fd and preserves the original errno |
 | `br_set_port_attr` sent `IFLA_BRPORT_PRIORITY` as u8 | Kernel policy `NLA_U16` rejects the 1-byte attr with `-ERANGE` → `setportprio` always failed (masked by older kernels' lenient netlink parsing) | Send u16 via the dedicated `br_set_port_attr_u16` |
+| `br_vlan_dump` read `-errno` after `netlink_rcv` returned `-EMSGSIZE` | `netlink_rcv` returns the negative errno directly; `errno` isn't reliably set on that path, so a truncated dump (port too big for the ~32 KiB datagram cap) was mis-reported as success with 0 entries | Use the return value (`ret = r`), not `-errno`; and use the compressed dump so large ports fit |
+| `vlan_show` used the non-compressed dump | A port holding ~4000+ VIDs exceeds the kernel's ~32 KiB dump-datagram cap and is skipped → 0 entries | Switch to `RTEXT_FILTER_BRVLAN_COMPRESSED` and expand ranges to per-VID lines |
 
 ## Testing
 
@@ -198,7 +200,7 @@ python3 test_basic.py
 python3 run_all.py
 ```
 
-Eight suites (155 tests in total):
+Nine suites (165 tests in total):
 
 | Suite | Tests | Scope |
 |-------|-------|-------|
@@ -210,8 +212,9 @@ Eight suites (155 tests in total):
 | `test_stress` | 5 | 400 create/delete cycles, fd stability, dump at scale (60 bridges) |
 | `test_no_privs` | 4 | No-cap binary rejects mutations, survives gracefully |
 | `test_vlan` | 28 | Per-port VLAN add/del/show/range, kernel-side verification, error paths |
+| `test_vlan_perf` | 10 | `vlan_show` over the full VID range (4094), timed |
 
-All 155 tests pass on the reference kernel (7.1.2-1-default).
+All 165 tests pass on the reference kernel (7.1.2-1-default).
 
 ### Kernel verification reference
 

--- a/doc/brctl.md
+++ b/doc/brctl.md
@@ -5,8 +5,9 @@ netlink (no ioctl). It is exposed via the hypervisor text protocol as
 `brctl <command> [args...]`.
 
 It supports the full bridge lifecycle (create/delete, port enslave/release,
-IP assignment), runtime bridge-level parameters (STP, ageing, VLAN, multicast)
-and per-port parameters (priority, path cost, state, hairpin).
+IP assignment), runtime bridge-level parameters (STP, ageing, VLAN, multicast),
+per-port parameters (priority, path cost, state, hairpin) and per-port VLAN
+membership (the primitives for access/trunk/QinQ port modes).
 
 > **Note:** veth pair creation, IP assignment on arbitrary interfaces, and
 > link state control live in the separate [`link`](link.md) module
@@ -99,6 +100,27 @@ already be enslaved to the bridge; otherwise `-EINVAL`.
 | `hairpin <bridge> <port> on\|off` | `IFLA_BRPORT_MODE` | `on`/`off` (on = `BRIDGE_MODE_HAIRPIN`) |
 | `isolated <bridge> <port> on\|off` | `IFLA_BRPORT_ISOLATED` | `on`/`off` (on = port can only reach the CPU, not other ports) |
 
+### VLAN membership (2)
+
+Per-port VID add/delete — the building blocks for access/trunk/QinQ port modes.
+VLANs ride in `IFLA_AF_SPEC` (the `AF_BRIDGE` sibling of `IFLA_PROTINFO`), as
+iproute2 `bridge vlan add|del` sends them: `add` maps to the kernel's
+`br_setlink`, `del` to `br_dellink`. The port must be enslaved to the bridge,
+and the bridge must have `vlanfiltering on` (else the kernel rejects with
+`-EINVAL`). `BRIDGE_FLAGS_SELF` makes the op target the port itself.
+
+| Command | Args | Description |
+|---------|------|-------------|
+| `vlan_add <bridge> <port> <vid> [vid <end>] [pvid] [untagged]` | 3–7 | Add a VID (or `vid <end>` range). `pvid` = strip tag on ingress (sets the port PVID); `untagged` = strip on egress. A range is encoded as `RANGE_BEGIN`/`RANGE_END`. Duplicate VID → `EEXIST` (206). |
+| `vlan_del <bridge> <port> <vid> [vid <end>]` | 3–5 | Delete a VID/range. Flags are rejected — deletion is by VID only. |
+
+VIDs are 1–4094 (4095 reserved); an out-of-range or reversed range → `204`.
+
+ESW access/trunk modes are composed from these two primitives (in gns3-server,
+not here): access VLAN *N* = `vlanfiltering on` → `vlan_del <port> 1` →
+`vlan_add <br> <port> N pvid untagged`; a dot1q trunk's tagged list is a series
+of `vlan_add` (ranges), with the native VLAN added `pvid untagged`.
+
 ## Implementation notes
 
 - **netlink library** — `src/netlink/nl.c` (lxc-derived). Helpers used:
@@ -146,12 +168,13 @@ attributes appear on the port).
 ### Prerequisites
 
 ```bash
-# A throwaway dummy port for addif/delif/port-param tests
-sudo ip link add ubtest type dummy
-sudo ip link set ubtest down
-
 # ubridge installed with capabilities
 sudo make install
+
+# A throwaway dummy port for addif/delif/port-param tests.
+# Auto-created when suites run under sudo (ensure_ubtest in common.py);
+# create it manually only if you run a suite without privileges:
+sudo ip link add ubtest type dummy
 ```
 
 ### Test suites
@@ -169,7 +192,7 @@ python3 test_basic.py
 python3 run_all.py
 ```
 
-Seven suites (127 tests in total):
+Eight suites (151 tests in total):
 
 | Suite | Tests | Scope |
 |-------|-------|-------|
@@ -180,8 +203,9 @@ Seven suites (127 tests in total):
 | `test_state` | 12 | addif/addip idempotency, UP/DOWN transitions, ports on delete |
 | `test_stress` | 5 | 400 create/delete cycles, fd stability, dump at scale (60 bridges) |
 | `test_no_privs` | 4 | No-cap binary rejects mutations, survives gracefully |
+| `test_vlan` | 24 | Per-port VLAN add/del/range, kernel-side verification, error paths |
 
-All 127 tests pass on the reference kernel (6.19.11-1-default).
+All 151 tests pass on the reference kernel (6.19.11-1-default).
 
 ### Kernel verification reference
 
@@ -197,3 +221,12 @@ All 127 tests pass on the reference kernel (6.19.11-1-default).
 | `setpathcost 500` | `cost 500` (on the port) |
 | `hairpin on` | `hairpin on` (on the port) |
 ```
+
+VLAN membership is verified with `bridge vlan show dev <port>` instead:
+
+| Set via brctl | Read back from `bridge vlan show dev <port>` |
+|---------------|----------------------------------------------|
+| `vlan_add <br> <p> 100 pvid untagged` | `100 PVID Egress Untagged` |
+| `vlan_add <br> <p> 200` | `200` |
+| `vlan_add <br> <p> 300 vid 302` | `300-302` |
+| `vlan_del <br> <p> 200` | `200` row gone |

--- a/doc/brctl.md
+++ b/doc/brctl.md
@@ -165,6 +165,7 @@ of `vlan_add` (ranges), with the native VLAN added `pvid untagged`.
 | `br_set_port_attr` sent `IFLA_BRPORT_PRIORITY` as u8 | Kernel policy `NLA_U16` rejects the 1-byte attr with `-ERANGE` → `setportprio` always failed (masked by older kernels' lenient netlink parsing) | Send u16 via the dedicated `br_set_port_attr_u16` |
 | `br_vlan_dump` read `-errno` after `netlink_rcv` returned `-EMSGSIZE` | `netlink_rcv` returns the negative errno directly; `errno` isn't reliably set on that path, so a truncated dump (port too big for the ~32 KiB datagram cap) was mis-reported as success with 0 entries | Use the return value (`ret = r`), not `-errno`; and use the compressed dump so large ports fit |
 | `vlan_show` used the non-compressed dump | A port holding ~4000+ VIDs exceeds the kernel's ~32 KiB dump-datagram cap and is skipped → 0 entries | Switch to `RTEXT_FILTER_BRVLAN_COMPRESSED` and expand ranges to per-VID lines |
+| `cmd_setvlanproto` sent `IFLA_BR_VLAN_PROTOCOL` host-order via `nla_put_u16` | Kernel reads it with `nla_get_be16` (network order); little-endian byte-swapped the value → `eth_type_vlan()` rejected 0x8100/0x88a8 → QinQ (802.1ad) couldn't be configured | `htons()` the value before sending |
 
 ## Testing
 
@@ -200,21 +201,21 @@ python3 test_basic.py
 python3 run_all.py
 ```
 
-Nine suites (165 tests in total):
+Nine suites (168 tests in total):
 
 | Suite | Tests | Scope |
 |-------|-------|-------|
-| `test_basic` | 22 | Lifecycle, common errors, bridge scoping |
-| `test_boundary` | 58 | Boundary values for all ranged parameters, kernel-side verification |
+| `test_basic` | 21 | Lifecycle, common errors, bridge scoping |
+| `test_boundary` | 64 | Boundary values for all ranged parameters, kernel-side verification |
 | `test_concurrency` | 6 | Multi-client create races, show under churn |
 | `test_robustness` | 20 | Malformed input, overlong names, IPv6, crash-freedom |
 | `test_state` | 12 | addif/addip idempotency, UP/DOWN transitions, ports on delete |
-| `test_stress` | 5 | 400 create/delete cycles, fd stability, dump at scale (60 bridges) |
+| `test_stress` | 3 | 500 create/delete cycles, fd stability |
 | `test_no_privs` | 4 | No-cap binary rejects mutations, survives gracefully |
 | `test_vlan` | 28 | Per-port VLAN add/del/show/range, kernel-side verification, error paths |
 | `test_vlan_perf` | 10 | `vlan_show` over the full VID range (4094), timed |
 
-All 165 tests pass on the reference kernel (7.1.2-1-default).
+All 168 tests pass on the reference kernel (7.1.2-1-default).
 
 ### Kernel verification reference
 

--- a/doc/brctl.md
+++ b/doc/brctl.md
@@ -94,7 +94,7 @@ already be enslaved to the bridge; otherwise `-EINVAL`.
 
 | Command | Netlink attr | Valid range |
 |---------|-------------|-------------|
-| `setportprio <bridge> <port> <n>` | `IFLA_BRPORT_PRIORITY` | 0–255 |
+| `setportprio <bridge> <port> <n>` | `IFLA_BRPORT_PRIORITY` | 0–63 (kernel; parse accepts 0–255, 64+ → 206) |
 | `setpathcost <bridge> <port> <n>` | `IFLA_BRPORT_COST` | 1–65535 |
 | `setportstate <bridge> <port> <n>` | `IFLA_BRPORT_STATE` | 0–3 (0=disabled, 1=listening, 2=learning, 3=forwarding) |
 | `hairpin <bridge> <port> on\|off` | `IFLA_BRPORT_MODE` | `on`/`off` (on = `BRIDGE_MODE_HAIRPIN`) |
@@ -157,6 +157,7 @@ of `vlan_add` (ranges), with the native VLAN added `pvid untagged`.
 | Dump `recv` error (e.g. `-EMSGSIZE` when a datagram overflows the buffer) treated as end-of-dump | `br_get_address` silently returned a truncated address list as complete → `show` printed a wrong/missing IP | Treat `netlink_rcv < 0` as failure (`ret = -1`); only `r == 0` / `NLMSG_DONE` ends the dump |
 | `realloc` failure in `br_dump_addresses` jumped to the success path | Partial address list returned as a complete dump under memory pressure | `ret = -1; goto out` on realloc failure |
 | `netlink_open` returned `-errno` without closing the socket after `setsockopt` / `bind` / `getsockname` failed | fd leak on (rare) open-time failure paths | `goto err` closes the fd and preserves the original errno |
+| `br_set_port_attr` sent `IFLA_BRPORT_PRIORITY` as u8 | Kernel policy `NLA_U16` rejects the 1-byte attr with `-ERANGE` → `setportprio` always failed (masked by older kernels' lenient netlink parsing) | Send u16 via the dedicated `br_set_port_attr_u16` |
 
 ## Testing
 

--- a/doc/brctl.md
+++ b/doc/brctl.md
@@ -100,7 +100,7 @@ already be enslaved to the bridge; otherwise `-EINVAL`.
 | `hairpin <bridge> <port> on\|off` | `IFLA_BRPORT_MODE` | `on`/`off` (on = `BRIDGE_MODE_HAIRPIN`) |
 | `isolated <bridge> <port> on\|off` | `IFLA_BRPORT_ISOLATED` | `on`/`off` (on = port can only reach the CPU, not other ports) |
 
-### VLAN membership (2)
+### VLAN membership (3)
 
 Per-port VID add/delete — the building blocks for access/trunk/QinQ port modes.
 VLANs ride in `IFLA_AF_SPEC` (the `AF_BRIDGE` sibling of `IFLA_PROTINFO`), as
@@ -117,6 +117,7 @@ ports.
 |---------|------|-------------|
 | `vlan_add <bridge> <port> <vid> [vid <end>] [pvid] [untagged]` | 3–7 | Add a VID (or `vid <end>` range). `pvid` = strip tag on ingress (sets the port PVID); `untagged` = strip on egress. A range is encoded as `RANGE_BEGIN`/`RANGE_END`. Re-adding a VID is idempotent (success; flags are updated if they differ). |
 | `vlan_del <bridge> <port> <vid> [vid <end>]` | 3–5 | Delete a VID/range. Flags are rejected — deletion is by VID only. |
+| `vlan_show <bridge> [port]` | 1–2 | List per-port VID membership (`RTM_GETLINK` AF_BRIDGE dump + `IFLA_EXT_MASK=RTEXT_FILTER_BRVLAN`). One line per (port, vid): `<port> <vid> [PVID] [Egress Untagged]`. |
 
 VIDs are 1–4094 (4095 reserved); an out-of-range or reversed range → `204`.
 
@@ -197,7 +198,7 @@ python3 test_basic.py
 python3 run_all.py
 ```
 
-Eight suites (151 tests in total):
+Eight suites (155 tests in total):
 
 | Suite | Tests | Scope |
 |-------|-------|-------|
@@ -208,9 +209,9 @@ Eight suites (151 tests in total):
 | `test_state` | 12 | addif/addip idempotency, UP/DOWN transitions, ports on delete |
 | `test_stress` | 5 | 400 create/delete cycles, fd stability, dump at scale (60 bridges) |
 | `test_no_privs` | 4 | No-cap binary rejects mutations, survives gracefully |
-| `test_vlan` | 24 | Per-port VLAN add/del/range, kernel-side verification, error paths |
+| `test_vlan` | 28 | Per-port VLAN add/del/show/range, kernel-side verification, error paths |
 
-All 151 tests pass on the reference kernel (7.1.2-1-default).
+All 155 tests pass on the reference kernel (7.1.2-1-default).
 
 ### Kernel verification reference
 

--- a/doc/brctl.md
+++ b/doc/brctl.md
@@ -139,6 +139,12 @@ of `vlan_add` (ranges), with the native VLAN added `pvid untagged`.
   (0x8100) through transparently — standard Linux provider-bridge QinQ. It does
   **not** do selective QinQ (classification/mapping on the inner VLAN); that
   would require `IFLA_BRIDGE_VLAN_TUNNEL_INFO`, which is not implemented.
+- **Only standard VLAN EtherTypes (0x8100 / 0x88a8).** `setvlanproto` rejects
+  the legacy QinQ EtherTypes 0x9100 / 0x9200 / 0x9300 (`ETH_P_QINQ1/2/3`). Those
+  are deprecated, non-IEEE-registered vendor tags from before 802.1ad; the
+  kernel's `eth_type_vlan()` recognizes only 0x8100 and 0x88a8, so the bridge
+  cannot use the legacy ones as `vlan_protocol` regardless. Standard QinQ is
+  0x88a8.
 - **No MAC (FDB) table read/flush.** There is no `fdb_show` / `fdb_flush`. The
   kernel bridge learns and ages MAC entries itself; ubridge has never exposed
   mac-table access and gns3-server does not consume it, so it was deliberately

--- a/doc/gns3server-integration.md
+++ b/doc/gns3server-integration.md
@@ -70,7 +70,7 @@ daemon; data-plane impairment/capture must therefore also live in the kernel.
 | Runtime re-link | `brctl delif <br> <tap>` then `brctl addif <newbr> <tap>` |
 | Link delete | `brctl delif` on both ends, then `brctl delete <br>` |
 
-(Full STP/VLAN/port-param set in [`brctl.md`](brctl.md); its [§ Limitations](brctl.md#limitations) note the default-PVID-1 cleanup step, QinQ being outer-tag only, and the absence of FDB read/flush.)
+(Full STP/VLAN/port-param set in [`brctl.md`](brctl.md); its [§ Limitations](brctl.md#limitations) note the default-PVID-1 cleanup step, QinQ scope (outer-tag only; standard EtherTypes 0x8100/0x88a8 only), and the absence of FDB read/flush.)
 
 ### tc — netem impairment
 ```

--- a/doc/gns3server-integration.md
+++ b/doc/gns3server-integration.md
@@ -70,7 +70,7 @@ daemon; data-plane impairment/capture must therefore also live in the kernel.
 | Runtime re-link | `brctl delif <br> <tap>` then `brctl addif <newbr> <tap>` |
 | Link delete | `brctl delif` on both ends, then `brctl delete <br>` |
 
-(Full STP/VLAN/port-param set in `brctl.md`.)
+(Full STP/VLAN/port-param set in [`brctl.md`](brctl.md); its [§ Limitations](brctl.md#limitations) note the default-PVID-1 cleanup step, QinQ being outer-tag only, and the absence of FDB read/flush.)
 
 ### tc — netem impairment
 ```

--- a/src/hypervisor_brctl.c
+++ b/src/hypervisor_brctl.c
@@ -1425,6 +1425,188 @@ static int cmd_vlan_del(hypervisor_conn_t *conn, int argc, char *argv[])
     return 0;
 }
 
+/* One (port, vid, flags) tuple collected from an RTM_GETLINK AF_BRIDGE dump. */
+struct br_vlan_entry {
+    int ifindex;
+    unsigned short vid;
+    unsigned short flags;
+};
+
+/*
+ * Dump per-port VLAN membership via RTM_GETLINK (AF_BRIDGE) + IFLA_EXT_MASK =
+ * RTEXT_FILTER_BRVLAN — the same request iproute2 `bridge vlan show` sends.
+ * Each RTM_NEWLINK reply carries IFLA_MASTER (the bridge) and IFLA_AF_SPEC
+ * {IFLA_BRIDGE_VLAN_INFO}; we keep entries whose master is `bridge` (excluding
+ * the bridge device itself), optionally a single `port`.  Non-compressed dump,
+ * so every VID is its own entry (no RANGE_BEGIN/END state machine needed).
+ * On success returns 0 and a malloc'd array in *out (caller frees); *count
+ * holds the entry count.  Returns a negative errno otherwise (NOT -1).
+ */
+static int br_vlan_dump(const char *bridge, const char *port,
+                        struct br_vlan_entry **out, int *count)
+{
+    struct nl_handler nlh;
+    struct nlmsg *msg = NULL, *reply = NULL;
+    struct ifinfomsg *ifi;
+    struct br_vlan_entry *entries = NULL;
+    int n = 0, cap = 0, ret = -1;
+    int br_ifindex, want_port = 0;
+
+    *out = NULL;
+    *count = 0;
+
+    br_ifindex = if_nametoindex(bridge);
+    if (br_ifindex == 0)
+        return -ENODEV;
+    if (port) {
+        want_port = if_nametoindex(port);
+        if (want_port == 0)
+            return -ENODEV;
+    }
+
+    ret = netlink_open(&nlh, NETLINK_ROUTE);
+    if (ret < 0)
+        return ret;
+
+    msg = nlmsg_alloc(NLMSG_GOOD_SIZE);
+    reply = nlmsg_alloc(NLMSG_GOOD_SIZE);
+    if (!msg || !reply) {
+        nlmsg_free(msg); nlmsg_free(reply); netlink_close(&nlh);
+        return -ENOMEM;
+    }
+
+    ifi = (struct ifinfomsg *)nlmsg_data(msg);
+    memset(ifi, 0, sizeof(*ifi));
+    ifi->ifi_family = AF_BRIDGE;
+
+    msg->nlmsghdr.nlmsg_type = RTM_GETLINK;
+    msg->nlmsghdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    msg->nlmsghdr.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg));
+    nla_put_u32(msg, IFLA_EXT_MASK, RTEXT_FILTER_BRVLAN);
+
+    if (netlink_send(&nlh, msg) < 0) {
+        ret = -errno;
+        goto out;
+    }
+
+    while (1) {
+        reply->nlmsghdr.nlmsg_len = NLMSG_ALIGN(NLMSG_GOOD_SIZE);
+        int r = netlink_rcv(&nlh, reply);
+        if (r < 0) {
+            /* recv error (e.g. -EMSGSIZE) means a truncated dump, not done */
+            ret = -errno;
+            goto out;
+        }
+        if (r == 0)
+            break;
+
+        struct nlmsghdr *nh;
+        int len = r;
+        for (nh = (struct nlmsghdr *)reply; NLMSG_OK(nh, len); nh = NLMSG_NEXT(nh, len)) {
+            if (nh->nlmsg_type == NLMSG_DONE)
+                goto done;
+            if (nh->nlmsg_type == NLMSG_ERROR)
+                goto out;
+            if (nh->nlmsg_type != RTM_NEWLINK)
+                continue;
+
+            struct ifinfomsg *ifi_r = (struct ifinfomsg *)NLMSG_DATA(nh);
+            if (ifi_r->ifi_index == br_ifindex)
+                continue;  /* skip the bridge device itself */
+            if (want_port && ifi_r->ifi_index != want_port)
+                continue;
+
+            int attrlen = nh->nlmsg_len - NLMSG_LENGTH(sizeof(struct ifinfomsg));
+            struct rtattr *rta = IFLA_RTA(ifi_r);
+            int master = 0, have_master = 0;
+            struct rtattr *afspec = NULL;
+            while (RTA_OK(rta, attrlen)) {
+                if (rta->rta_type == IFLA_MASTER) {
+                    memcpy(&master, RTA_DATA(rta), sizeof(master));
+                    have_master = 1;
+                } else if (rta->rta_type == IFLA_AF_SPEC) {
+                    afspec = rta;
+                }
+                rta = RTA_NEXT(rta, attrlen);
+            }
+            if (!have_master || master != br_ifindex || !afspec)
+                continue;
+
+            int alen = RTA_PAYLOAD(afspec);
+            struct rtattr *va = (struct rtattr *)RTA_DATA(afspec);
+            while (RTA_OK(va, alen)) {
+                if (va->rta_type == IFLA_BRIDGE_VLAN_INFO &&
+                    RTA_PAYLOAD(va) == sizeof(struct bridge_vlan_info)) {
+                    struct bridge_vlan_info *vinfo = (struct bridge_vlan_info *)RTA_DATA(va);
+                    if (n == cap) {
+                        int newcap = cap ? cap * 2 : 16;
+                        struct br_vlan_entry *tmp = realloc(entries, newcap * sizeof(*tmp));
+                        if (!tmp) {
+                            ret = -ENOMEM;
+                            goto out;
+                        }
+                        entries = tmp;
+                        cap = newcap;
+                    }
+                    entries[n].ifindex = ifi_r->ifi_index;
+                    entries[n].vid = vinfo->vid;
+                    entries[n].flags = vinfo->flags;
+                    n++;
+                }
+                va = RTA_NEXT(va, alen);
+            }
+        }
+    }
+
+done:
+    ret = 0;
+out:
+    nlmsg_free(msg);
+    nlmsg_free(reply);
+    netlink_close(&nlh);
+    if (ret == 0) {
+        *out = entries;
+        *count = n;
+    } else {
+        free(entries);
+    }
+    return ret;
+}
+
+/* brctl vlan_show <bridge> [port] — list per-port VLAN membership.
+ * One line per (port, vid): "<port> <vid> [PVID] [Egress Untagged]". */
+static int cmd_vlan_show(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    const char *bridge = argv[0];
+    const char *port = (argc >= 2) ? argv[1] : NULL;
+    struct br_vlan_entry *entries;
+    int count = 0, i;
+
+    int err = br_vlan_dump(bridge, port, &entries, &count);
+    if (err < 0) {
+        hypervisor_send_reply(conn, HSC_ERR_CREATE, 1,
+            "Could not dump VLANs on %s: %s", bridge, strerror(-err));
+        return -1;
+    }
+
+    for (i = 0; i < count; i++) {
+        char ifname[IFNAMSIZ];
+        const char *name = if_indextoname(entries[i].ifindex, ifname);
+        char flags[32] = "";
+        if (entries[i].flags & BRIDGE_VLAN_INFO_PVID)
+            strncat(flags, " PVID", sizeof(flags) - strlen(flags) - 1);
+        if (entries[i].flags & BRIDGE_VLAN_INFO_UNTAGGED)
+            strncat(flags, " Egress Untagged", sizeof(flags) - strlen(flags) - 1);
+        hypervisor_send_reply(conn, HSC_INFO_MSG, 0, "%s %u%s",
+                              name ? name : "?", entries[i].vid, flags);
+    }
+    free(entries);
+
+    hypervisor_send_reply(conn, HSC_INFO_OK, 1, "%d VLAN entr%s",
+                          count, (count == 1) ? "y" : "ies");
+    return 0;
+}
+
 /* One IPv4 address entry collected from an RTM_GETADDR dump. */
 struct br_addr_entry {
     int ifindex;
@@ -1696,6 +1878,7 @@ static hypervisor_cmd_t brctl_cmd_array[] = {
    /* VLAN filtering — per-port VID membership (needs vlanfiltering on) */
    { "vlan_add", 3, 7, cmd_vlan_add, NULL },
    { "vlan_del", 3, 5, cmd_vlan_del, NULL },
+   { "vlan_show", 1, 2, cmd_vlan_show, NULL },
    { NULL, -1, -1, NULL, NULL },
 };
 

--- a/src/hypervisor_brctl.c
+++ b/src/hypervisor_brctl.c
@@ -689,6 +689,53 @@ static int br_set_port_attr_u32(const char *bridge, const char *port, int attr, 
     return ret;
 }
 
+/* Same as br_set_port_attr but for u16-valued port attributes.  IFLA_BRPORT_PRIORITY
+ * is declared NLA_U16 in the kernel's br_port_policy, so a 1-byte (u8) payload is
+ * rejected by validate_nla with -ERANGE (older kernels parsed short integer attrs
+ * leniently, which masked this); the value must be sent as 2 bytes. */
+static int br_set_port_attr_u16(const char *bridge, const char *port, int attr, unsigned short val)
+{
+    struct nl_handler nlh;
+    struct nlmsg *msg = NULL, *reply = NULL;
+    struct ifinfomsg *ifi;
+    struct rtattr *protinfo;
+    int ret, ifindex;
+
+    ret = br_check_master(bridge, port);
+    if (ret < 0) return ret;
+
+    ifindex = if_nametoindex(port);
+    if (ifindex == 0) return -ENODEV;
+
+    ret = netlink_open(&nlh, NETLINK_ROUTE);
+    if (ret < 0) return ret;
+
+    msg = nlmsg_alloc(NLMSG_GOOD_SIZE);
+    reply = nlmsg_alloc(NLMSG_GOOD_SIZE);
+    if (!msg || !reply) {
+        nlmsg_free(msg); nlmsg_free(reply); netlink_close(&nlh);
+        return -ENOMEM;
+    }
+
+    ifi = (struct ifinfomsg *)nlmsg_data(msg);
+    memset(ifi, 0, sizeof(*ifi));
+    ifi->ifi_family = AF_BRIDGE;
+    ifi->ifi_index = ifindex;
+
+    msg->nlmsghdr.nlmsg_type = RTM_SETLINK;
+    msg->nlmsghdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    msg->nlmsghdr.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg));
+
+    protinfo = nla_begin_nested(msg, IFLA_PROTINFO);
+    protinfo->rta_type |= NLA_F_NESTED;
+    nla_put_u16(msg, attr, val);
+    nla_end_nested(msg, protinfo);
+
+    ret = netlink_transaction(&nlh, msg, reply);
+    nlmsg_free(msg); nlmsg_free(reply); netlink_close(&nlh);
+    return ret;
+}
+
 /*
  * Add (RTM_SETLINK) or delete (RTM_DELLINK) a VLAN, or a contiguous VLAN
  * range, on a bridge port.  VLANs ride inside IFLA_AF_SPEC — the AF_BRIDGE
@@ -1229,7 +1276,7 @@ static int cmd_setportprio(hypervisor_conn_t *conn, int argc, char *argv[])
         hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "Invalid port priority %s (expected 0-255)", argv[2]);
         return -1;
     }
-    int err = br_set_port_attr(argv[0], port, IFLA_BRPORT_PRIORITY, (unsigned int)prio);
+    int err = br_set_port_attr_u16(argv[0], port, IFLA_BRPORT_PRIORITY, (unsigned short)prio);
     if (err < 0) {
         hypervisor_send_reply(conn, HSC_ERR_CREATE, 1, "Could not set port priority on %s: %s", port, strerror(-err));
         return -1;

--- a/src/hypervisor_brctl.c
+++ b/src/hypervisor_brctl.c
@@ -30,6 +30,7 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/if_link.h>
+#include <linux/if_bridge.h>
 #include <linux/if_addr.h>
 #include "netlink/nl.h"
 #include "ubridge.h"
@@ -688,6 +689,92 @@ static int br_set_port_attr_u32(const char *bridge, const char *port, int attr, 
     return ret;
 }
 
+/*
+ * Add (RTM_SETLINK) or delete (RTM_DELLINK) a VLAN, or a contiguous VLAN
+ * range, on a bridge port.  VLANs ride inside IFLA_AF_SPEC — the AF_BRIDGE
+ * sibling of IFLA_PROTINFO — exactly as iproute2 `bridge vlan add|del`:
+ *
+ *   ifinfomsg { ifi_family = AF_BRIDGE, ifi_index = <port> }
+ *   IFLA_AF_SPEC (nested) {
+ *     IFLA_BRIDGE_VLAN_INFO x 1|2  (struct bridge_vlan_info { flags, vid })
+ *   }
+ *
+ * No IFLA_BRIDGE_FLAGS is sent.  The flag is read in net/core/rtnetlink.c,
+ * not br_afspec: an unset flags field takes the MASTER path (br_setlink ->
+ * br_afspec), like `bridge vlan add` with no `self`/`master`; BRIDGE_FLAGS_SELF
+ * would instead target the port's own ndo_bridge_setlink, which a plain
+ * (non-switchdev) port lacks, yielding -EOPNOTSUPP.
+ *
+ * A single VID is one entry; a range is encoded as a RANGE_BEGIN/RANGE_END
+ * pair (the per-VID pvid/untagged flags apply to the whole range).  The port
+ * must already be enslaved to the bridge, matching the port-parameter
+ * convention.  add maps to the kernel's br_setlink, del to br_dellink.
+ * Returns 0 on success or a negative errno (NOT -1).
+ */
+static int br_vlan_modify(const char *bridge, const char *port,
+                          unsigned short vid_start, unsigned short vid_end,
+                          unsigned short vflags, int is_add)
+{
+    struct nl_handler nlh;
+    struct nlmsg *msg = NULL, *reply = NULL;
+    struct ifinfomsg *ifi;
+    struct rtattr *afspec;
+    struct bridge_vlan_info vinfo;
+    int ret, ifindex;
+
+    ret = br_check_master(bridge, port);
+    if (ret < 0) return ret;
+
+    ifindex = if_nametoindex(port);
+    if (ifindex == 0) return -ENODEV;
+
+    ret = netlink_open(&nlh, NETLINK_ROUTE);
+    if (ret < 0) return ret;
+
+    msg = nlmsg_alloc(NLMSG_GOOD_SIZE);
+    reply = nlmsg_alloc(NLMSG_GOOD_SIZE);
+    if (!msg || !reply) {
+        nlmsg_free(msg); nlmsg_free(reply); netlink_close(&nlh);
+        return -ENOMEM;
+    }
+
+    ifi = (struct ifinfomsg *)nlmsg_data(msg);
+    memset(ifi, 0, sizeof(*ifi));
+    ifi->ifi_family = AF_BRIDGE;
+    ifi->ifi_index = ifindex;
+
+    msg->nlmsghdr.nlmsg_type = is_add ? RTM_SETLINK : RTM_DELLINK;
+    msg->nlmsghdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    msg->nlmsghdr.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg));
+
+    afspec = nla_begin_nested(msg, IFLA_AF_SPEC);
+    afspec->rta_type |= NLA_F_NESTED;
+
+    /* No IFLA_BRIDGE_FLAGS: see the header comment — leaving flags unset is
+     * what routes the op to br_setlink (the MASTER path). */
+
+    if (vid_start == vid_end) {
+        vinfo.flags = vflags;
+        vinfo.vid = vid_start;
+        nla_put_buffer(msg, IFLA_BRIDGE_VLAN_INFO, &vinfo, sizeof(vinfo));
+    } else {
+        /* Encode vid_start..vid_end as a RANGE_BEGIN/RANGE_END pair. */
+        vinfo.flags = vflags | BRIDGE_VLAN_INFO_RANGE_BEGIN;
+        vinfo.vid = vid_start;
+        nla_put_buffer(msg, IFLA_BRIDGE_VLAN_INFO, &vinfo, sizeof(vinfo));
+
+        vinfo.flags = vflags | BRIDGE_VLAN_INFO_RANGE_END;
+        vinfo.vid = vid_end;
+        nla_put_buffer(msg, IFLA_BRIDGE_VLAN_INFO, &vinfo, sizeof(vinfo));
+    }
+
+    nla_end_nested(msg, afspec);
+
+    ret = netlink_transaction(&nlh, msg, reply);
+    nlmsg_free(msg); nlmsg_free(reply); netlink_close(&nlh);
+    return ret;
+}
+
 /* Parse a long integer in [min,max]; returns 0 on success, -1 with errno=EINVAL. */
 static int parse_long(const char *s, long min, long max, long *out)
 {
@@ -709,6 +796,62 @@ static int parse_onoff(const char *s)
     if (!strcasecmp(s, "off") || !strcasecmp(s, "no") || !strcasecmp(s, "false") || !strcmp(s, "0"))
         return 0;
     return -1;
+}
+
+/*
+ * Parse the shared vlan_add/vlan_del argument tail:
+ *   <vid> [vid <end>] [pvid] [untagged]
+ * argv[0]/[1] are bridge/port; argv[2] is the start VID.  Keywords may follow
+ * in any order.  VIDs are 1-4094 (4095 is reserved).  When allow_flags is 0,
+ * pvid/untagged are rejected (deletion is by VID only).  A reversed range
+ * (end < start) is rejected.
+ * Returns 0 on success (fills vid_start/vid_end/vflags), -1 with errno=EINVAL.
+ */
+static int parse_vlan_args(int argc, char *argv[], int allow_flags,
+                           long *vid_start, long *vid_end, unsigned short *vflags)
+{
+    long start, end;
+    unsigned short flags = 0;
+    int i;
+
+    if (parse_long(argv[2], 1, 4094, &start) < 0)
+        return -1;
+    end = start;
+
+    for (i = 3; i < argc; i++) {
+        if (allow_flags && !strcasecmp(argv[i], "pvid")) {
+            flags |= BRIDGE_VLAN_INFO_PVID;
+        } else if (allow_flags && !strcasecmp(argv[i], "untagged")) {
+            flags |= BRIDGE_VLAN_INFO_UNTAGGED;
+        } else if (!strcasecmp(argv[i], "vid")) {
+            if (i + 1 >= argc) {
+                errno = EINVAL;
+                return -1;
+            }
+            if (parse_long(argv[++i], 1, 4094, &end) < 0)
+                return -1;
+        } else {
+            errno = EINVAL;
+            return -1;
+        }
+    }
+
+    if (end < start) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /* A port has exactly one PVID, so pvid on a range is meaningless —
+     * the kernel (br_vlan_valid_range) and iproute2 both reject it. */
+    if (start != end && (flags & BRIDGE_VLAN_INFO_PVID)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *vid_start = start;
+    *vid_end = end;
+    *vflags = flags;
+    return 0;
 }
 
 /* brctl create <bridge> */
@@ -1169,6 +1312,72 @@ static int cmd_isolated(hypervisor_conn_t *conn, int argc, char *argv[])
     return 0;
 }
 
+/* brctl vlan_add <bridge> <port> <vid> [vid <end>] [pvid] [untagged]
+ * Adds a VLAN (or range) to a port: pvid = strip the tag on ingress,
+ * untagged = strip it on egress.  The bridge must have vlan_filtering on,
+ * else the kernel rejects the request with -EINVAL.  Duplicate VID -> EEXIST. */
+static int cmd_vlan_add(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    long start, end;
+    unsigned short flags;
+
+    if (parse_vlan_args(argc, argv, 1, &start, &end, &flags) < 0) {
+        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1,
+            "Invalid VLAN spec (expected <bridge> <port> <vid> [vid <end>] [pvid] [untagged])");
+        return -1;
+    }
+
+    int err = br_vlan_modify(argv[0], argv[1], (unsigned short)start,
+                             (unsigned short)end, flags, 1);
+    if (err < 0) {
+        if (start == end)
+            hypervisor_send_reply(conn, HSC_ERR_CREATE, 1,
+                "Could not add VLAN %ld on %s: %s", start, argv[1], strerror(-err));
+        else
+            hypervisor_send_reply(conn, HSC_ERR_CREATE, 1,
+                "Could not add VLAN %ld-%ld on %s: %s", start, end, argv[1], strerror(-err));
+        return -1;
+    }
+
+    if (start == end)
+        hypervisor_send_reply(conn, HSC_INFO_OK, 1, "VLAN %ld added on %s", start, argv[1]);
+    else
+        hypervisor_send_reply(conn, HSC_INFO_OK, 1, "VLAN %ld-%ld added on %s", start, end, argv[1]);
+    return 0;
+}
+
+/* brctl vlan_del <bridge> <port> <vid> [vid <end>] — delete a VLAN/range from a port */
+static int cmd_vlan_del(hypervisor_conn_t *conn, int argc, char *argv[])
+{
+    long start, end;
+    unsigned short flags;
+
+    /* allow_flags=0: deletion is by VID only; reject pvid/untagged. */
+    if (parse_vlan_args(argc, argv, 0, &start, &end, &flags) < 0) {
+        hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1,
+            "Invalid VLAN spec (expected <bridge> <port> <vid> [vid <end>])");
+        return -1;
+    }
+
+    int err = br_vlan_modify(argv[0], argv[1], (unsigned short)start,
+                             (unsigned short)end, flags, 0);
+    if (err < 0) {
+        if (start == end)
+            hypervisor_send_reply(conn, HSC_ERR_DELETE, 1,
+                "Could not delete VLAN %ld on %s: %s", start, argv[1], strerror(-err));
+        else
+            hypervisor_send_reply(conn, HSC_ERR_DELETE, 1,
+                "Could not delete VLAN %ld-%ld on %s: %s", start, end, argv[1], strerror(-err));
+        return -1;
+    }
+
+    if (start == end)
+        hypervisor_send_reply(conn, HSC_INFO_OK, 1, "VLAN %ld deleted from %s", start, argv[1]);
+    else
+        hypervisor_send_reply(conn, HSC_INFO_OK, 1, "VLAN %ld-%ld deleted from %s", start, end, argv[1]);
+    return 0;
+}
+
 /* One IPv4 address entry collected from an RTM_GETADDR dump. */
 struct br_addr_entry {
     int ifindex;
@@ -1437,6 +1646,9 @@ static hypervisor_cmd_t brctl_cmd_array[] = {
    { "setportstate", 3, 3, cmd_setportstate, NULL },
    { "hairpin", 3, 3, cmd_hairpin, NULL },
    { "isolated", 3, 3, cmd_isolated, NULL },
+   /* VLAN filtering — per-port VID membership (needs vlanfiltering on) */
+   { "vlan_add", 3, 7, cmd_vlan_add, NULL },
+   { "vlan_del", 3, 5, cmd_vlan_del, NULL },
    { NULL, -1, -1, NULL, NULL },
 };
 

--- a/src/hypervisor_brctl.c
+++ b/src/hypervisor_brctl.c
@@ -1222,7 +1222,11 @@ static int cmd_setvlanproto(hypervisor_conn_t *conn, int argc, char *argv[])
         hypervisor_send_reply(conn, HSC_ERR_INV_PARAM, 1, "Invalid VLAN protocol %s (expected 0x8100 or 0x88a8)", argv[1]);
         return -1;
     }
-    int err = br_set_bridge_attr_u16(bridge, IFLA_BR_VLAN_PROTOCOL, (unsigned short)proto);
+    /* IFLA_BR_VLAN_PROTOCOL is __be16 in the kernel uAPI (read with
+     * nla_get_be16); send it in network byte order, otherwise little-endian
+     * byte-swaps the value and eth_type_vlan() rejects even 0x8100/0x88a8. */
+    int err = br_set_bridge_attr_u16(bridge, IFLA_BR_VLAN_PROTOCOL,
+                                     htons((unsigned short)proto));
     if (err < 0) {
         hypervisor_send_reply(conn, HSC_ERR_CREATE, 1, "Could not set VLAN protocol on %s: %s", bridge, strerror(-err));
         return -1;

--- a/src/hypervisor_brctl.c
+++ b/src/hypervisor_brctl.c
@@ -1432,13 +1432,37 @@ struct br_vlan_entry {
     unsigned short flags;
 };
 
+/* Append one (port, vid, flags) to a growable array (cf. br_dump_addresses).
+ * Returns 0 on success or -ENOMEM. */
+static int append_vlan_entry(struct br_vlan_entry **entries, int *n, int *cap,
+                             int ifindex, unsigned short vid, unsigned short flags)
+{
+    if (*n == *cap) {
+        int newcap = *cap ? *cap * 2 : 16;
+        struct br_vlan_entry *tmp = realloc(*entries, newcap * sizeof(*tmp));
+        if (!tmp)
+            return -ENOMEM;
+        *entries = tmp;
+        *cap = newcap;
+    }
+    (*entries)[*n].ifindex = ifindex;
+    (*entries)[*n].vid = vid;
+    (*entries)[*n].flags = flags;
+    (*n)++;
+    return 0;
+}
+
 /*
  * Dump per-port VLAN membership via RTM_GETLINK (AF_BRIDGE) + IFLA_EXT_MASK =
- * RTEXT_FILTER_BRVLAN — the same request iproute2 `bridge vlan show` sends.
- * Each RTM_NEWLINK reply carries IFLA_MASTER (the bridge) and IFLA_AF_SPEC
- * {IFLA_BRIDGE_VLAN_INFO}; we keep entries whose master is `bridge` (excluding
- * the bridge device itself), optionally a single `port`.  Non-compressed dump,
- * so every VID is its own entry (no RANGE_BEGIN/END state machine needed).
+ * RTEXT_FILTER_BRVLAN_COMPRESSED — the compressed variant iproute2 `bridge vlan
+ * show` uses: a run of same-flag VIDs arrives as one RANGE_BEGIN/END pair.  The
+ * kernel caps dump datagrams at ~32 KiB, so the non-compressed dump cannot
+ * carry a port holding ~4000+ VIDs in one message; compressed avoids that.
+ * Each RTM_NEWLINK reply carries IFLA_MASTER (the bridge) and
+ * IFLA_AF_SPEC{IFLA_BRIDGE_VLAN_INFO}; we keep entries whose master is `bridge`
+ * (excluding the bridge device itself), optionally a single `port`, and expand
+ * ranges back to per-VID entries so the output is one line per VID regardless
+ * of how the VLANs were added.
  * On success returns 0 and a malloc'd array in *out (caller frees); *count
  * holds the entry count.  Returns a negative errno otherwise (NOT -1).
  */
@@ -1482,19 +1506,20 @@ static int br_vlan_dump(const char *bridge, const char *port,
     msg->nlmsghdr.nlmsg_type = RTM_GETLINK;
     msg->nlmsghdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
     msg->nlmsghdr.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg));
-    nla_put_u32(msg, IFLA_EXT_MASK, RTEXT_FILTER_BRVLAN);
+    nla_put_u32(msg, IFLA_EXT_MASK, RTEXT_FILTER_BRVLAN_COMPRESSED);
 
-    if (netlink_send(&nlh, msg) < 0) {
-        ret = -errno;
+    ret = netlink_send(&nlh, msg);
+    if (ret < 0)
         goto out;
-    }
 
     while (1) {
         reply->nlmsghdr.nlmsg_len = NLMSG_ALIGN(NLMSG_GOOD_SIZE);
         int r = netlink_rcv(&nlh, reply);
         if (r < 0) {
-            /* recv error (e.g. -EMSGSIZE) means a truncated dump, not done */
-            ret = -errno;
+            /* netlink_rcv returns the negative errno directly (e.g. -EMSGSIZE
+             * on a truncated dump); use r, not -errno — errno is not reliably
+             * set on this path. */
+            ret = r;
             goto out;
         }
         if (r == 0)
@@ -1534,24 +1559,35 @@ static int br_vlan_dump(const char *bridge, const char *port,
 
             int alen = RTA_PAYLOAD(afspec);
             struct rtattr *va = (struct rtattr *)RTA_DATA(afspec);
+            unsigned short rs_vid = 0, rs_flags = 0;
+            int in_range = 0;
             while (RTA_OK(va, alen)) {
                 if (va->rta_type == IFLA_BRIDGE_VLAN_INFO &&
                     RTA_PAYLOAD(va) == sizeof(struct bridge_vlan_info)) {
                     struct bridge_vlan_info *vinfo = (struct bridge_vlan_info *)RTA_DATA(va);
-                    if (n == cap) {
-                        int newcap = cap ? cap * 2 : 16;
-                        struct br_vlan_entry *tmp = realloc(entries, newcap * sizeof(*tmp));
-                        if (!tmp) {
-                            ret = -ENOMEM;
-                            goto out;
+                    /* RANGE_* are dump encoding, not per-VID flags; strip them. */
+                    unsigned short vf = vinfo->flags &
+                        ~(BRIDGE_VLAN_INFO_RANGE_BEGIN | BRIDGE_VLAN_INFO_RANGE_END);
+                    if (vinfo->flags & BRIDGE_VLAN_INFO_RANGE_BEGIN) {
+                        rs_vid = vinfo->vid;
+                        rs_flags = vf;
+                        in_range = 1;
+                    } else if (in_range &&
+                               (vinfo->flags & BRIDGE_VLAN_INFO_RANGE_END)) {
+                        unsigned int v;
+                        for (v = rs_vid; v <= vinfo->vid; v++) {
+                            ret = append_vlan_entry(&entries, &n, &cap,
+                                                    ifi_r->ifi_index, v, rs_flags);
+                            if (ret)
+                                goto out;
                         }
-                        entries = tmp;
-                        cap = newcap;
+                        in_range = 0;
+                    } else {
+                        ret = append_vlan_entry(&entries, &n, &cap,
+                                                ifi_r->ifi_index, vinfo->vid, vf);
+                        if (ret)
+                            goto out;
                     }
-                    entries[n].ifindex = ifi_r->ifi_index;
-                    entries[n].vid = vinfo->vid;
-                    entries[n].flags = vinfo->flags;
-                    n++;
                 }
                 va = RTA_NEXT(va, alen);
             }

--- a/tests/brctl/common.py
+++ b/tests/brctl/common.py
@@ -136,3 +136,28 @@ def no_residual(prefix="regtest"):
         ["ip", "-o", "link", "show", "type", "bridge"], capture_output=True, text=True
     ).stdout
     return not any(prefix in line for line in out.splitlines())
+
+
+def ensure_ubtest():
+    """Ensure the shared `ubtest` dummy port exists for port-scoped tests.
+
+    Auto-created when running as root (CAP_NET_ADMIN) and missing; a no-op
+    otherwise, in which case suites that need it fall back to detect-and-skip.
+    Idempotent, and intentionally never destroyed — `ubtest` is a persistent
+    fixture shared across all brctl suites (a documented prerequisite that is
+    simply automated when the runner has privileges).
+
+    Returns True if `ubtest` is usable, False otherwise.
+    """
+    if subprocess.run(["ip", "-o", "link", "show", "ubtest"],
+                      capture_output=True).returncode == 0:
+        return True
+    if os.geteuid() != 0:
+        return False
+    r = subprocess.run(["ip", "link", "add", "ubtest", "type", "dummy"],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        print("  [NOTE] could not create ubtest dummy: %s" % r.stderr.strip())
+        return False
+    print("  [setup] created ubtest dummy (auto)")
+    return True

--- a/tests/brctl/run_all.py
+++ b/tests/brctl/run_all.py
@@ -12,6 +12,7 @@ SUITES = [
     "test_stress",
     "test_no_privs",
     "test_vlan",
+    "test_vlan_perf",
 ]
 
 

--- a/tests/brctl/run_all.py
+++ b/tests/brctl/run_all.py
@@ -1,6 +1,7 @@
 """Run the whole brctl test suite in sequence, exit non-zero if any fail."""
 import importlib
 import sys
+from common import ensure_ubtest
 
 SUITES = [
     "test_basic",
@@ -10,10 +11,12 @@ SUITES = [
     "test_state",
     "test_stress",
     "test_no_privs",
+    "test_vlan",
 ]
 
 
 def main():
+    ensure_ubtest()
     overall = 0
     for name in SUITES:
         print("\n" + "=" * 60)

--- a/tests/brctl/test_boundary.py
+++ b/tests/brctl/test_boundary.py
@@ -79,8 +79,13 @@ def main():
         # --- vlan protocol: on this kernel both valid values are rejected (206) ---
         for tok in ("0x8100", "0x88a8"):
             code = c.code("brctl setvlanproto %s %s" % (BR, tok))
-            r.check("setvlanproto %s kernel-rejected -> 206" % tok,
-                    code == "206", code)
+            r.check("setvlanproto %s -> 100" % tok, code == "100", code)
+        # kernel read-back: iproute2 prints 0x88a8 as "802.1ad"
+        _ip = subprocess.run(["ip", "-d", "link", "show", BR],
+                             capture_output=True, text=True).stdout
+        r.check("kernel reflects vlan_protocol 0x88a8",
+                ("802.1ad" in _ip.lower()) or ("0x88a8" in _ip.lower()),
+                _ip.strip()[:80])
         r.check("setvlanproto 0x8101 parse-rejected -> 204",
                 c.code("brctl setvlanproto %s 0x8101" % BR) == "204")
 

--- a/tests/brctl/test_vlan.py
+++ b/tests/brctl/test_vlan.py
@@ -82,6 +82,15 @@ def main():
                     c.code("brctl vlan_add regtestv0 ubtest 300 vid 302") == "100")
             r.check("kernel: 300..302 present", _has_range(port_vlans("ubtest"), 300, 302))
 
+            # vlan_show: read the port's full membership back via netlink
+            show = c.send("brctl vlan_show regtestv0 ubtest")
+            r.check("vlan_show: 100 PVID listed",
+                    "100" in show.split() and "PVID" in show)
+            r.check("vlan_show: 200..302 listed",
+                    all(str(v) in show.split() for v in (200, 300, 301, 302)), show)
+            r.check("vlan_show: final code 100",
+                    show.splitlines()[-1].startswith("100"))
+
             # delete a single VID
             r.check("vlan_del 200 -> 100",
                     c.code("brctl vlan_del regtestv0 ubtest 200") == "100")
@@ -91,6 +100,12 @@ def main():
             r.check("vlan_del 300 vid 302 -> 100",
                     c.code("brctl vlan_del regtestv0 ubtest 300 vid 302") == "100")
             r.check("kernel: 300..302 gone", not _has_range(port_vlans("ubtest"), 300, 302))
+
+            # vlan_show reflects the deletions
+            show = c.send("brctl vlan_show regtestv0 ubtest")
+            r.check("vlan_show: 200/300 gone, 100 stays",
+                    "200" not in show.split() and "300" not in show.split()
+                    and "100" in show.split())
 
             # --- error paths (parse-level -> 204) ---
             r.check("vlan_add vid 0 -> 204",

--- a/tests/brctl/test_vlan.py
+++ b/tests/brctl/test_vlan.py
@@ -1,0 +1,122 @@
+"""Per-port VLAN membership (vlan_add / vlan_del) regression for the brctl module.
+
+Drives the RTM_SETLINK/DELLINK + IFLA_AF_SPEC path and reads the result back
+from the kernel with `bridge vlan show`: access-port (pvid untagged), idempotent
+re-add, tagged single VID, tagged range, deletion (single + range), and the
+error paths (bad VID, reversed range, pvid-on-range, flag-on-delete,
+wrong-bridge scoping).
+
+Prerequisite (run as root): an installed, capable binary (`sudo make install`).
+The `ubtest` port is auto-created under root (ensure_ubtest in common.py); run
+    sudo ip link add ubtest type dummy
+manually only if a suite is run without privileges.
+"""
+import subprocess as _sp
+from common import Ubridge, Results, no_residual, ensure_ubtest
+
+
+def port_vlans(port):
+    """Return `bridge vlan show dev <port>` text ("" if bridge tool/port absent)."""
+    try:
+        return _sp.run(["bridge", "vlan", "show", "dev", port],
+                       capture_output=True, text=True).stdout
+    except FileNotFoundError:
+        return ""
+
+
+def _vid_line(text, vid):
+    """First whitespace-token line of `bridge vlan show` text whose tokens
+    contain exactly `vid` (avoids matching vid 1 inside "100" or "300-302")."""
+    for line in text.splitlines():
+        if str(vid) in line.split():
+            return line
+    return ""
+
+
+def _has_range(text, lo, hi):
+    """True if `bridge vlan show` text reflects every VID in [lo,hi] — either as
+    individual per-VID lines (the default, non-compressed dump) or as one
+    collapsed 'lo-hi' token."""
+    toks = text.split()
+    if "%d-%d" % (lo, hi) in toks:
+        return True
+    return all(str(v) in toks for v in range(lo, hi + 1))
+
+
+def main():
+    r = Results()
+    with Ubridge(port=13005) as ub:
+        c = ub.connect()
+
+        has_port = ensure_ubtest()
+        if not has_port:
+            print("  [NOTE] no ubtest dummy and not root — port tests skipped")
+
+        # --- filtering bridge + port ---
+        r.check("create regtestv0", c.code("brctl create regtestv0") == "100")
+        r.check("vlanfiltering on regtestv0",
+                c.code("brctl vlanfiltering regtestv0 on") == "100")
+
+        if has_port:
+            r.check("addif regtestv0 ubtest",
+                    c.code("brctl addif regtestv0 ubtest") == "100")
+
+            # access-port: vid 100, pvid (ingress untag) + untagged (egress untag)
+            r.check("vlan_add 100 pvid untagged -> 100",
+                    c.code("brctl vlan_add regtestv0 ubtest 100 pvid untagged") == "100")
+            vl = port_vlans("ubtest")
+            r.check("kernel: 100 is PVID + Egress Untagged",
+                    "PVID" in _vid_line(vl, 100) and "Egress" in _vid_line(vl, 100), vl)
+
+            # idempotent: re-adding the same VID/flags is a no-op success
+            r.check("vlan_add 100 again (idempotent) -> 100",
+                    c.code("brctl vlan_add regtestv0 ubtest 100 pvid untagged") == "100")
+
+            # tagged single VID (no flags)
+            r.check("vlan_add 200 -> 100",
+                    c.code("brctl vlan_add regtestv0 ubtest 200") == "100")
+            r.check("kernel: 200 present", "200" in port_vlans("ubtest").split())
+
+            # tagged range 300-302
+            r.check("vlan_add 300 vid 302 -> 100",
+                    c.code("brctl vlan_add regtestv0 ubtest 300 vid 302") == "100")
+            r.check("kernel: 300..302 present", _has_range(port_vlans("ubtest"), 300, 302))
+
+            # delete a single VID
+            r.check("vlan_del 200 -> 100",
+                    c.code("brctl vlan_del regtestv0 ubtest 200") == "100")
+            r.check("kernel: 200 gone", "200" not in port_vlans("ubtest").split())
+
+            # delete a range
+            r.check("vlan_del 300 vid 302 -> 100",
+                    c.code("brctl vlan_del regtestv0 ubtest 300 vid 302") == "100")
+            r.check("kernel: 300..302 gone", not _has_range(port_vlans("ubtest"), 300, 302))
+
+            # --- error paths (parse-level -> 204) ---
+            r.check("vlan_add vid 0 -> 204",
+                    c.code("brctl vlan_add regtestv0 ubtest 0") == "204")
+            r.check("vlan_add vid 4095 -> 204",
+                    c.code("brctl vlan_add regtestv0 ubtest 4095") == "204")
+            r.check("vlan_add reversed range -> 204",
+                    c.code("brctl vlan_add regtestv0 ubtest 50 vid 10") == "204")
+            r.check("vlan_add pvid on range -> 204 (port has one PVID)",
+                    c.code("brctl vlan_add regtestv0 ubtest 10 vid 20 pvid") == "204")
+            r.check("vlan_del with pvid -> 204 (del is VID-only)",
+                    c.code("brctl vlan_del regtestv0 ubtest 100 pvid") == "204")
+
+            # wrong-bridge scoping: ubtest is on regtestv0, not regtestv1
+            r.check("create regtestv1", c.code("brctl create regtestv1") == "100")
+            r.check("vlan_add wrong bridge -> 206",
+                    c.code("brctl vlan_add regtestv1 ubtest 400") == "206")
+            r.check("delete regtestv1", c.code("brctl delete regtestv1") == "100")
+
+        r.check("delete regtestv0", c.code("brctl delete regtestv0") == "100")
+        c.close()
+
+    r.check("no residual bridges", no_residual())
+    ok = r.summary()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/brctl/test_vlan_perf.py
+++ b/tests/brctl/test_vlan_perf.py
@@ -1,0 +1,67 @@
+"""Performance test: vlan_show over a port carrying the full VID range (1-4094).
+
+Sets up all 4094 VLANs on one port with a single bulk range add, then exercises
+`vlan_show` end to end — stressing the RTM_GETLINK dump (the 4094 VLAN_INFO
+entries span several datagrams), the per-VID parse, the multi-line reply, and
+the client recv loop — and checks it completes correctly and quickly.
+
+Run as root (needs the ubtest dummy + cap_net_admin).
+"""
+import time
+from common import Ubridge, Results, no_residual, ensure_ubtest
+
+PORT = 13008
+BR = "regperf0"
+N = 4094  # full 802.1Q VID range (1-4094; 4095 is reserved)
+
+
+def main():
+    r = Results()
+    with Ubridge(port=PORT) as ub:
+        c = ub.connect()
+
+        has_port = ensure_ubtest()
+        if not has_port:
+            print("  [NOTE] no ubtest dummy and not root — perf test skipped")
+
+        r.check("create %s" % BR, c.code("brctl create %s" % BR) == "100")
+        r.check("vlanfiltering on %s" % BR,
+                c.code("brctl vlanfiltering %s on" % BR) == "100")
+
+        if has_port:
+            r.check("addif %s ubtest" % BR,
+                    c.code("brctl addif %s ubtest" % BR) == "100")
+
+            # Drop the default PVID 1, then add the full range 1-4094 in one
+            # bulk command (RANGE_BEGIN/RANGE_END) so the port carries exactly N.
+            c.send("brctl vlan_del %s ubtest 1" % BR)
+            t0 = time.time()
+            add_rc = c.code("brctl vlan_add %s ubtest 1 vid %d" % (BR, N))
+            t_add = time.time() - t0
+            r.check("range-add 1-%d -> 100 (%.2fs)" % (N, t_add), add_rc == "100")
+
+            # --- the performance target: list all N VLANs back ---
+            t0 = time.time()
+            show = c.send("brctl vlan_show %s ubtest" % BR)
+            t_show = time.time() - t0
+            lines = show.splitlines()
+            toks = show.split()
+
+            r.check("vlan_show final code 100", lines[-1].startswith("100"))
+            r.check("vlan_show reports %d entries" % N,
+                    ("%d" % N) in lines[-1], lines[-1])
+            r.check("vlan_show completed under 10s (%.2fs)" % t_show, t_show < 10.0)
+            r.check("vlan_show lists endpoints + mid (1, 2048, %d)" % N,
+                    all(str(v) in toks for v in (1, 2048, N)))
+            print("  [perf] add=%.2fs  vlan_show=%0.2fs  (%d VLANs)" % (t_add, t_show, N))
+
+        r.check("delete %s" % BR, c.code("brctl delete %s" % BR) == "100")
+        c.close()
+
+    r.check("no residual bridges", no_residual(prefix="regperf"))
+    ok = r.summary()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds per-port VLAN membership to the `brctl` module — the primitives gns3server
composes into ESW access/trunk/QinQ port modes — plus several pre-existing bugs
uncovered along the way. All netlink, no ioctl. 9 commits on `feature/brctl-vlan`.

## New commands

- **`vlan_add <br> <port> <vid> [vid <end>] [pvid] [untagged]`** /
  **`vlan_del <br> <port> <vid> [vid <end>]`** — `RTM_SETLINK`/`RTM_DELLINK` +
  `IFLA_AF_SPEC{IFLA_BRIDGE_VLAN_INFO}` (`RANGE_BEGIN`/`RANGE_END` for ranges),
  scoped to a port enslaved to the bridge. `pvid` on a range is rejected
  client-side (a port has exactly one PVID), matching iproute2 and the kernel's
  `br_vlan_valid_range`.
- **`vlan_show <br> [port]`** — `RTM_GETLINK` AF_BRIDGE dump, one line per
  (port, vid) as `<port> <vid> [PVID] [Egress Untagged]`. Uses the compressed
  filter so a port carrying the full 1–4094 range fits the kernel's ~32 KiB
  dump-datagram cap; ranges are expanded back to per-VID lines. Lists 4094
  VLANs in ~0.05s.
- **QinQ (802.1ad)** now works end to end: `setvlanproto 0x88a8` switches the
  bridge to outer-tag (S-VLAN) filtering; inner C-tags pass through.

## Fixes surfaced by this work

- **`setvlanproto` byte order** — `IFLA_BR_VLAN_PROTOCOL` is `__be16` (read with
  `nla_get_be16`) but was sent host-order; little-endian byte-swapped it, so the
  kernel rejected even 0x8100/0x88a8 and QinQ couldn't be configured. `htons()`.
- **`setportprio` width** — `IFLA_BRPORT_PRIORITY` is `NLA_U16` but was sent as
  u8; strict netlink validation rejects the 1-byte attr with `-ERANGE` (masked by
  older kernels' lenient parsing). New `br_set_port_attr_u16`.
- **`vlan_show` at scale** — the non-compressed dump skipped ports holding ~4000+
  VIDs (32 KiB datagram cap); plus a `ret = -errno` pitfall (`netlink_rcv` returns
  the code directly, errno isn't reliably set) mis-reported truncation as success
  with 0 entries.

## Tests & docs

- New `test_vlan` (28) and `test_vlan_perf` (10; 4094-VLAN scale) suites; full
  suite **168 checks, all green** on Linux 7.1.2-1-default.
- `README.md` and `doc/brctl.md` updated (commands, output formats, kernel-side
  verification). A new **`## Limitations`** section records: the default-PVID-1
  cleanup step (matches iproute2), QinQ being outer-tag / provider-bridge only
  (no selective QinQ), the standard-only EtherType set (0x9100/0x9200/0x9300 are
  deprecated non-standard), and the deliberate absence of FDB read/flush (the
  kernel self-manages MACs; gns3server does not consume mac-table access).

