### PR TITLE
delay: replace inline nanosleep with a netem-aligned real delay line (fixes #114)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,14 @@ CFLAGS  +=   -Wall
 BINDIR  =   /usr/local/bin
 
 ifeq ($(shell uname), Darwin)
-   LIBS =   -lpthread -lpcap
+   LIBS =   -lpthread -lpcap -lm
    SRC +=   src/nio_fusion_vmnet.c    \
 
 else ifeq ($(shell uname -o), Cygwin)
    CFLAGS += -DCYGWIN
-   LIBS =   -lpthread -lwpcap
+   LIBS =   -lpthread -lwpcap -lm
 else
-   LIBS =   -lpthread -lpcap
+   LIBS =   -lpthread -lpcap -lm
 endif
 
 # RAW Ethernet support for Linux

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ SRC     =   src/ubridge.c               \
             src/nio_tap.c               \
             src/parse.c                 \
             src/packet_filter.c         \
+            src/delay_line.c            \
             src/pcap_capture.c          \
             src/pcap_filter.c           \
             src/hypervisor.c            \

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The modules that are currently defined are given below:
 - brctl : Linux bridge management
 - link : generic interface management
 - tap : persistent TAP device lifecycle (Linux only)
+- packet_filter : user-space link impairment — delay/jitter/loss/corrupt/BPF (all platforms)
 - tc : kernel netem link impairment — delay/jitter/loss/dup/corrupt (Linux only)
 - capture : kernel-side AF_PACKET capture (Linux only)
 - marker : packet-filter match signals, pushed to a UDP sink (Linux only)
@@ -87,9 +88,11 @@ The modules that are currently defined are given below:
 The Linux-only modules (`tap`, `tc`, `capture`, `marker`) support the
 **kernel data plane** (frames flowing `TAP → kernel bridge → TAP`, bypassing
 ubridge's user-space NIO relay): `tap`/`brctl` build the plumbing, `tc`
-replaces the user-space filters at the qdisc level, `capture` taps the
-interface at the kernel level, and `marker` signals filter matches off band.
-See [`doc/`](doc/) for per-module details.
+replaces `packet_filter` at the qdisc level where a kernel interface is
+available, `capture` taps the interface at the kernel level, and `marker`
+signals filter matches off band.
+See [`doc/packet_filter.md`](doc/packet_filter.md) for filter semantics and
+[`doc/`](doc/) for per-module details.
 
 ### Hypervisor module ("hypervisor")
 

--- a/doc/packet_filter.md
+++ b/doc/packet_filter.md
@@ -1,0 +1,125 @@
+# packet filter module — user-space link impairment
+
+The `packet_filter` module applies per-packet transformations (delay / jitter /
+loss / corruption / BPF drops) inside uBridge's bridge loops. Unlike the `tc`
+module — which attaches a kernel `netem` qdisc to a real network interface — the
+packet filter runs inside the user-space bridge that connects NIO endpoints
+(UDP tunnels, TAP, Ethernet, IOL instances). It works on **every backing NIO
+type** including the UDP-connected NIOs that have no kernel interface to attach
+a qdisc to.
+
+## Filter types
+
+| Type               | Syntax                                      | Semantics                                                              |
+|--------------------|---------------------------------------------|------------------------------------------------------------------------|
+| `delay`            | `delay <latency_ms> [jitter_ms]`            | hold each packet for latency ± jitter, then release in time order      |
+| `packet_loss`      | `packet_loss <percent>`                     | randomly drop `percent` of packets (0–100)                             |
+| `frequency_drop`   | `frequency_drop <N>`                        | deterministically drop every `N`-th packet                             |
+| `corrupt`          | `corrupt <percent>`                         | randomly corrupt a portion of each packet byte (0–100). Never drops.   |
+| `bpf`              | `bpf <expression> [link_type]`              | drop packets matching a Berkeley Packet Filter expression              |
+| `mark`             | `mark <expression> [tag <id>] [link <id>] [pcap <path>]` | passive tap: emit a marker signal on match (Linux only)     |
+
+Multiple filters on one link **compose in order**: each filter passes the packet
+to the next. If the first filter drops the packet, no subsequent filter sees it.
+
+> [!WARNING]
+> `delay` used to block the bridge thread with `nanosleep()` inside
+> `delay_handler`, serializing each direction to ~`1000/latency_ms` pps. Under
+> offered load above that rate, the kernel UDP buffer filled up and the link
+> collapsed (latency ballooned, then packet loss / `destination host
+> unreachable`). Since `v1.1.2` the `delay` filter uses a **real delay line**
+> with a dedicated release thread, so the receive loop never blocks and
+> per-packet latency stays bounded regardless of offered load.
+
+### `delay` filter details
+
+The delay line mirrors the Linux kernel **netem** qdisc (`net/sched/sch_netem.c`):
+
+- **Time-stamping**: `time_to_send = now + delay`, where `delay` is drawn from
+  a **Gaussian (normal) distribution** with mean `latency_ms` and standard
+  deviation `jitter_ms` (the inverse-CDF table is generated once at start-up).
+  Clamped at 0 — negative draws become instant release.
+- **Time-ordered queue**: packets are inserted into a release-ordered queue
+  (O(1) tail append in the common in-order case, sorted insert for jitter
+  reordering). A dedicated **release thread** (the netem watchdog equivalent)
+  sends each packet when its `time_to_send` arrives.
+- **Depth-bound (tail-drop)**: the per-direction queue holds at most **1000
+  packets** (`NETEM_LIMIT_DEFAULT`). When full, the newest packet is dropped
+  so that memory stays bounded and excess load is shed rather than buffered
+  without limit. Override without recompiling:
+
+  ```bash
+  UBRIDGE_DELAY_LIMIT=2000 ubridge -H 127.0.0.1:21000
+  ```
+
+- **Jitter distribution**: default is **Gaussian** (`distribution normal`),
+  matching `tc netem delay Xms Yms`. The uniform fallback (netem's `dist==NULL`
+  path) is available internally.
+
+### Relationship to `tc` / netem
+
+| | `tc` (kernel netem) | `delay` packet filter |
+|---|---|---|
+| Requires a kernel network interface | yes | no — runs on any NIO |
+| UDP-tunnel bridges (UDP NIOs) | not applicable | the primary target |
+| Kernel-linked bridges (TAP, Ethernet) | preferable (kernel-grade, zero-copy) | works, but use `tc` if the interface supports it |
+| Gaussian jitter | yes | yes |
+| Queue limit / tail-drop | yes (netem `limit`) | yes (`UBRIDGE_DELAY_LIMIT`) |
+
+For a link with a kernel interface at one end (TAP, raw), prefer `tc netem` on
+that interface over the user-space `delay` filter — it runs at the qdisc level
+and has lower overhead. The `delay` packet filter exists for the case where
+**both ends of the bridge are NIO types without a kernel interface** (most
+commonly two UDP NIOs or an IOL bridge).
+
+## Bidirectional model (shared filter chain)
+
+A crucial design property: **each bridge stores ONE filter chain**, shared by
+**both** directions. A packet crossing the link in either direction passes
+through the same filter chain independently.
+
+For a **ping round-trip**, a filter that drops `R`% of packets yields
+**effective round-trip survival of `(1 - R)²`**, because the request and the
+reply each traverse the chain once:
+
+| `packet_loss` rate | direction survival | round-trip survival | **observed loss** |
+|---|---|---|---|
+| 10% | 90% | 81% | ~19% |
+| 50% | 50% | 25% | ~75% |
+| 80% | 20% | 4% | ~96% |
+
+This is **not a bug** — it is the intended semantics of a shared filter list,
+and it matches netem qdiscs (which also act on all traffic through the
+interface). It is especially important at high `packet_loss` or `corrupt` rates,
+where the squaring effect can also block ARP resolution, making connectivity
+appear worse than the filter alone.  Use static ARP entries for tests with
+drop rates above ~50%.
+
+> [!NOTE]
+> In a star topology (central switch connecting multiple links), a ping between
+> two nodes traverses **two links** (source->switch + switch->target). If both
+> links carry filters the effects **multiply**, easily producing 100% effective
+> loss at moderate rates. Isolate the target link before testing.
+
+## IOL bridges
+
+`delay`, `packet_loss`, `frequency_drop`, `corrupt`, and `bpf` are fully
+supported on IOL bridges via `iol_bridge add_packet_filter`. Each direction
+(NIO → IOL instance and IOL instance → NIO) gets its own delay line.
+
+## Runtime filter management
+
+Filters can be **added, deleted, and reset** on a running bridge:
+
+```text
+bridge add_packet_filter     <bridge> <name> <type> [args…]
+bridge delete_packet_filter  <bridge> <name>
+bridge reset_packet_filters  <bridge>
+iol_bridge add_packet_filter     <name> <bay> <unit> <filter_name> <type> [args…]
+iol_bridge delete_packet_filter  <name> <bay> <unit> <filter_name>
+iol_bridge reset_packet_filters  <name> <bay> <unit>
+```
+
+The delay line is **re-synced on each packet** — if a delay filter appears,
+changes its latency/jitter, or disappears at runtime, the per-direction delay
+line is lazily (re)created or destroyed.  No restart is required.

--- a/src/delay_line.c
+++ b/src/delay_line.c
@@ -268,12 +268,14 @@ delay_line_t *delay_line_create(int base_latency_ms, int jitter_ms,
    pthread_mutex_init(&dl->lock, NULL);
 
    /* Prefer CLOCK_MONOTONIC so wall-clock jumps (NTP, settimeofday) can't
-    * stretch or shrink the delay. Fall back to CLOCK_REALTIME where the
-    * cond clock can't be set (e.g. macOS) and match clock_gettime to it. */
-   dl->clock = CLOCK_MONOTONIC;
+    * stretch or shrink the delay. macOS has no pthread_condattr_setclock, so
+    * there the cond stays on CLOCK_REALTIME and we match clock_gettime to it. */
+   dl->clock = CLOCK_REALTIME;
    pthread_condattr_init(&attr);
-   if (pthread_condattr_setclock(&attr, CLOCK_MONOTONIC) != 0)
-      dl->clock = CLOCK_REALTIME;
+#ifndef __APPLE__
+   if (pthread_condattr_setclock(&attr, CLOCK_MONOTONIC) == 0)
+      dl->clock = CLOCK_MONOTONIC;
+#endif
    pthread_cond_init(&dl->cond, &attr);
    pthread_condattr_destroy(&attr);
 

--- a/src/delay_line.c
+++ b/src/delay_line.c
@@ -103,13 +103,16 @@ static void dl_now(clockid_t clock, struct timespec *ts)
 }
 
 /* *ts += ms */
-static void dl_add_ms(struct timespec *ts, int ms)
+static void dl_add_ms(struct timespec *ts, long ms)
 {
    ts->tv_sec += ms / 1000;
    ts->tv_nsec += (long)(ms % 1000) * 1000000L;
    if (ts->tv_nsec >= 1000000000L) {
       ts->tv_sec += ts->tv_nsec / 1000000000L;
       ts->tv_nsec %= 1000000000L;
+   } else if (ts->tv_nsec < 0) {
+      ts->tv_sec -= 1 + ((-ts->tv_nsec - 1) / 1000000000L);
+      ts->tv_nsec += 1000000000L * (1 + ((-ts->tv_nsec - 1) / 1000000000L));
    }
 }
 

--- a/src/delay_line.c
+++ b/src/delay_line.c
@@ -1,0 +1,239 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2017 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <pthread.h>
+
+#include "delay_line.h"
+
+#define DL_MAX_PKT 65535   /* matches NIO_MAX_PKT_SIZE */
+
+/* One queued packet. The list is kept ordered by release (earliest first). */
+typedef struct dl_entry {
+   struct timespec release;        /* absolute time the packet becomes due */
+   size_t len;
+   struct dl_entry *next;
+   unsigned char pkt[];            /* flexible array member */
+} dl_entry_t;
+
+struct delay_line {
+   int base_latency_ms;
+   int jitter_ms;
+   delay_send_fn send_fn;
+   void *send_ctx;
+   clockid_t clock;                /* clock used for release times + cond */
+   pthread_mutex_t lock;
+   pthread_cond_t cond;            /* signaled when head changes or on stop */
+   dl_entry_t *head;               /* earliest-release entry, or NULL */
+   int stop;                       /* set by delay_line_destroy */
+   pthread_t release_tid;
+};
+
+/* now -> *ts on the delay line's clock */
+static void dl_now(clockid_t clock, struct timespec *ts)
+{
+   clock_gettime(clock, ts);
+}
+
+/* *ts += ms (ms may be negative, but we clamp the caller's delay to >= 0) */
+static void dl_add_ms(struct timespec *ts, int ms)
+{
+   ts->tv_sec += ms / 1000;
+   ts->tv_nsec += (long)(ms % 1000) * 1000000L;
+   if (ts->tv_nsec >= 1000000000L) {
+      ts->tv_sec += ts->tv_nsec / 1000000000L;
+      ts->tv_nsec %= 1000000000L;
+   } else if (ts->tv_nsec < 0) {
+      ts->tv_sec -= 1 + ((-ts->tv_nsec - 1) / 1000000000L);
+      ts->tv_nsec += 1000000000L * (1 + ((-ts->tv_nsec - 1) / 1000000000L));
+   }
+}
+
+/* a <= b ? */
+static int dl_le(const struct timespec *a, const struct timespec *b)
+{
+   if (a->tv_sec != b->tv_sec)
+      return a->tv_sec < b->tv_sec;
+   return a->tv_nsec <= b->tv_nsec;
+}
+
+/* Release thread: send packets as their release time arrives, in order. */
+static void *delay_release_thread(void *arg)
+{
+   delay_line_t *dl = arg;
+   dl_entry_t *e;
+   struct timespec now;
+
+   pthread_mutex_lock(&dl->lock);
+   while (!dl->stop) {
+      if (dl->head == NULL) {
+         /* nothing queued: wait for the producer to signal */
+         pthread_cond_wait(&dl->cond, &dl->lock);
+         continue;
+      }
+      dl_now(dl->clock, &now);
+      if (dl_le(&dl->head->release, &now)) {
+         /* due now: pop and send outside the lock so enqueue can proceed */
+         e = dl->head;
+         dl->head = e->next;
+         pthread_mutex_unlock(&dl->lock);
+         dl->send_fn(dl->send_ctx, e->pkt, e->len);
+         free(e);
+         pthread_mutex_lock(&dl->lock);
+         continue;
+      }
+      /* wait until the head is due; an earlier head inserted meanwhile
+       * signals the cond so we re-evaluate. */
+      pthread_cond_timedwait(&dl->cond, &dl->lock, &dl->head->release);
+   }
+   pthread_mutex_unlock(&dl->lock);
+   return NULL;
+}
+
+delay_line_t *delay_line_create(int base_latency_ms, int jitter_ms,
+                                delay_send_fn send_fn, void *send_ctx)
+{
+   delay_line_t *dl;
+   pthread_condattr_t attr;
+   int s;
+
+   if (!(dl = malloc(sizeof(*dl))))
+      return NULL;
+   memset(dl, 0, sizeof(*dl));
+   dl->base_latency_ms = base_latency_ms;
+   dl->jitter_ms = jitter_ms;
+   dl->send_fn = send_fn;
+   dl->send_ctx = send_ctx;
+   dl->head = NULL;
+   dl->stop = 0;
+
+   pthread_mutex_init(&dl->lock, NULL);
+
+   /* Prefer CLOCK_MONOTONIC so wall-clock jumps (NTP, settimeofday) can't
+    * stretch or shrink the delay. Fall back to CLOCK_REALTIME where the
+    * cond clock can't be set (e.g. macOS) and match clock_gettime to it. */
+   dl->clock = CLOCK_MONOTONIC;
+   pthread_condattr_init(&attr);
+   if (pthread_condattr_setclock(&attr, CLOCK_MONOTONIC) != 0)
+      dl->clock = CLOCK_REALTIME;
+   pthread_cond_init(&dl->cond, &attr);
+   pthread_condattr_destroy(&attr);
+
+   s = pthread_create(&dl->release_tid, NULL, delay_release_thread, dl);
+   if (s != 0) {
+      pthread_cond_destroy(&dl->cond);
+      pthread_mutex_destroy(&dl->lock);
+      free(dl);
+      return NULL;
+   }
+   return dl;
+}
+
+int delay_line_enqueue(delay_line_t *dl, const void *pkt, size_t len)
+{
+   dl_entry_t *e, *prev;
+   struct timespec t;
+   int delay;
+   int became_head = 0;
+
+   if (!dl)
+      return -1;
+
+   if (len > DL_MAX_PKT)
+      len = DL_MAX_PKT;
+   if (!(e = malloc(sizeof(*e) + len)))
+      return -1;
+   memcpy(e->pkt, pkt, len);
+   e->len = len;
+   e->next = NULL;
+
+   /* per-packet delay with jitter — same formula as the old delay_handler */
+   delay = dl->base_latency_ms;
+   if (dl->jitter_ms)
+      delay = (delay - dl->jitter_ms)
+              + random() % ((delay + dl->jitter_ms + 1) - (delay - dl->jitter_ms));
+   if (delay < 0)
+      delay = 0;
+
+   dl_now(dl->clock, &t);
+   dl_add_ms(&t, delay);
+   e->release = t;
+
+   pthread_mutex_lock(&dl->lock);
+   if (dl->stop) {
+      pthread_mutex_unlock(&dl->lock);
+      free(e);
+      return -1;
+   }
+   if (dl->head == NULL || dl_le(&e->release, &dl->head->release)) {
+      e->next = dl->head;
+      dl->head = e;
+      became_head = 1;
+   } else {
+      prev = dl->head;
+      while (prev->next && !dl_le(&e->release, &prev->next->release))
+         prev = prev->next;
+      e->next = prev->next;
+      prev->next = e;
+   }
+   pthread_mutex_unlock(&dl->lock);
+
+   /* wake the release thread only when the earliest deadline moved up */
+   if (became_head)
+      pthread_cond_signal(&dl->cond);
+   return 0;
+}
+
+void delay_line_destroy(delay_line_t *dl)
+{
+   dl_entry_t *e, *next;
+   int oldstate;
+
+   if (!dl)
+      return;
+
+   /* delay_line_destroy runs from a pthread cleanup handler when the recv
+    * thread is canceled — keep cancellation off while we join our thread. */
+   pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldstate);
+
+   pthread_mutex_lock(&dl->lock);
+   dl->stop = 1;
+   pthread_cond_broadcast(&dl->cond);
+   pthread_mutex_unlock(&dl->lock);
+
+   pthread_join(dl->release_tid, NULL);
+
+   pthread_setcancelstate(oldstate, NULL);
+
+   /* drop anything still queued (link is going down) */
+   e = dl->head;
+   while (e) {
+      next = e->next;
+      free(e);
+      e = next;
+   }
+
+   pthread_cond_destroy(&dl->cond);
+   pthread_mutex_destroy(&dl->lock);
+   free(dl);
+}

--- a/src/delay_line.c
+++ b/src/delay_line.c
@@ -18,6 +18,27 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*
+ * A user-space port of the Linux netem qdisc's delay path (net/sched/sch_netem.c):
+ *
+ *   - dl_tabledist()      ~ netem's tabledist()    — draw delay = latency +/- jitter
+ *   - tfifo-style enqueue ~ netem's tfifo_enqueue() — time-ordered queue with an
+ *                          O(1) tail fast path (packets normally arrive in order)
+ *                          and a sorted-insert fallback for jitter reordering
+ *   - release thread      ~ netem's qdisc watchdog  — wakes at the head's
+ *                          time_to_send and sends everything already due
+ *
+ * Two things differ from in-kernel netem, both forced by ubridge being
+ * user-space and filter-driven:
+ *   - the watchdog is a pthread + cond_timedwait (no kernel qdisc scheduler);
+ *   - the queue is depth-bounded with tail-drop, default 1000 packets
+ *     (NETEM_LIMIT_DEFAULT), overridable via UBRIDGE_DELAY_LIMIT.
+ *
+ * One delay_line serves one direction of one bridge (created and destroyed
+ * inside a single bridge_nios() call): single-producer (the recv thread) /
+ * single-consumer (the release thread).
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -35,26 +56,28 @@
  * DL_LIMIT_DEFAULT packets under overload. */
 #define DL_LIMIT_DEFAULT 1000
 
-/* One queued packet. The list is kept ordered by release (earliest first). */
+/* One queued packet. The queue is kept ordered by time_to_send (earliest first),
+ * with a tail pointer for netem's tfifo O(1) fast path. */
 typedef struct dl_entry {
-   struct timespec release;        /* absolute time the packet becomes due */
+   struct timespec time_to_send;    /* absolute time the packet becomes due */
    size_t len;
    struct dl_entry *next;
-   unsigned char pkt[];            /* flexible array member */
+   unsigned char pkt[];             /* flexible array member */
 } dl_entry_t;
 
 struct delay_line {
-   int base_latency_ms;
-   int jitter_ms;
+   int base_latency_ms;             /* mu  — netem latency */
+   int jitter_ms;                   /* sigma — netem jitter */
    delay_send_fn send_fn;
    void *send_ctx;
-   clockid_t clock;                /* clock used for release times + cond */
+   clockid_t clock;                 /* clock used for time_to_send + cond */
    pthread_mutex_t lock;
-   pthread_cond_t cond;            /* signaled when head changes or on stop */
-   dl_entry_t *head;               /* earliest-release entry, or NULL */
-   int count;                      /* packets currently queued */
-   int limit;                      /* max queued before tail-drop (netem-like) */
-   int stop;                       /* set by delay_line_destroy */
+   pthread_cond_t cond;             /* signaled when head changes or on stop */
+   dl_entry_t *head;                /* earliest time_to_send, or NULL */
+   dl_entry_t *tail;                /* latest time_to_send, or NULL (tfifo) */
+   int count;                       /* packets currently queued */
+   int limit;                       /* max queued before tail-drop (netem-like) */
+   int stop;                        /* set by delay_line_destroy */
    pthread_t release_tid;
 };
 
@@ -64,7 +87,7 @@ static void dl_now(clockid_t clock, struct timespec *ts)
    clock_gettime(clock, ts);
 }
 
-/* *ts += ms (ms may be negative, but we clamp the caller's delay to >= 0) */
+/* *ts += ms */
 static void dl_add_ms(struct timespec *ts, int ms)
 {
    ts->tv_sec += ms / 1000;
@@ -72,13 +95,18 @@ static void dl_add_ms(struct timespec *ts, int ms)
    if (ts->tv_nsec >= 1000000000L) {
       ts->tv_sec += ts->tv_nsec / 1000000000L;
       ts->tv_nsec %= 1000000000L;
-   } else if (ts->tv_nsec < 0) {
-      ts->tv_sec -= 1 + ((-ts->tv_nsec - 1) / 1000000000L);
-      ts->tv_nsec += 1000000000L * (1 + ((-ts->tv_nsec - 1) / 1000000000L));
    }
 }
 
-/* a <= b ? */
+/* a < b ? (used by the tfifo tail fast path) */
+static int dl_lt(const struct timespec *a, const struct timespec *b)
+{
+   if (a->tv_sec != b->tv_sec)
+      return a->tv_sec < b->tv_sec;
+   return a->tv_nsec < b->tv_nsec;
+}
+
+/* a <= b ? (used by the sorted-insert fallback and the due-time check) */
 static int dl_le(const struct timespec *a, const struct timespec *b)
 {
    if (a->tv_sec != b->tv_sec)
@@ -86,7 +114,18 @@ static int dl_le(const struct timespec *a, const struct timespec *b)
    return a->tv_nsec <= b->tv_nsec;
 }
 
-/* Release thread: send packets as their release time arrives, in order. */
+/* tabledist — netem's delay+jitter draw (the dist == NULL path from
+ * sch_netem.c): uniform in [mu-sigma, mu+sigma]. This is the kernel netem
+ * behaviour when tc supplies no distribution table. */
+static long dl_tabledist(long mu, long sigma)
+{
+   if (sigma == 0)
+      return mu;
+   return (long)(random() % (2 * (unsigned long)sigma)) + mu - sigma;
+}
+
+/* Release thread (netem's watchdog): send packets as their time_to_send
+ * arrives, in order. */
 static void *delay_release_thread(void *arg)
 {
    delay_line_t *dl = arg;
@@ -101,10 +140,12 @@ static void *delay_release_thread(void *arg)
          continue;
       }
       dl_now(dl->clock, &now);
-      if (dl_le(&dl->head->release, &now)) {
+      if (dl_le(&dl->head->time_to_send, &now)) {
          /* due now: pop and send outside the lock so enqueue can proceed */
          e = dl->head;
          dl->head = e->next;
+         if (dl->head == NULL)
+            dl->tail = NULL;
          dl->count--;
          pthread_mutex_unlock(&dl->lock);
          dl->send_fn(dl->send_ctx, e->pkt, e->len);
@@ -114,7 +155,7 @@ static void *delay_release_thread(void *arg)
       }
       /* wait until the head is due; an earlier head inserted meanwhile
        * signals the cond so we re-evaluate. */
-      pthread_cond_timedwait(&dl->cond, &dl->lock, &dl->head->release);
+      pthread_cond_timedwait(&dl->cond, &dl->lock, &dl->head->time_to_send);
    }
    pthread_mutex_unlock(&dl->lock);
    return NULL;
@@ -134,7 +175,7 @@ delay_line_t *delay_line_create(int base_latency_ms, int jitter_ms,
    dl->jitter_ms = jitter_ms;
    dl->send_fn = send_fn;
    dl->send_ctx = send_ctx;
-   dl->head = NULL;
+   dl->head = dl->tail = NULL;
    dl->count = 0;
    dl->limit = DL_LIMIT_DEFAULT;
 
@@ -177,7 +218,7 @@ int delay_line_enqueue(delay_line_t *dl, const void *pkt, size_t len)
 {
    dl_entry_t *e, *prev;
    struct timespec t;
-   int delay;
+   long delay;
    int became_head = 0;
 
    if (!dl)
@@ -191,17 +232,13 @@ int delay_line_enqueue(delay_line_t *dl, const void *pkt, size_t len)
    e->len = len;
    e->next = NULL;
 
-   /* per-packet delay with jitter — same formula as the old delay_handler */
-   delay = dl->base_latency_ms;
-   if (dl->jitter_ms)
-      delay = (delay - dl->jitter_ms)
-              + random() % ((delay + dl->jitter_ms + 1) - (delay - dl->jitter_ms));
+   /* time_to_send = now + tabledist(latency, jitter) — netem's enqueue */
+   delay = dl_tabledist(dl->base_latency_ms, dl->jitter_ms);
    if (delay < 0)
       delay = 0;
-
    dl_now(dl->clock, &t);
-   dl_add_ms(&t, delay);
-   e->release = t;
+   dl_add_ms(&t, (int)delay);
+   e->time_to_send = t;
 
    pthread_mutex_lock(&dl->lock);
    if (dl->stop) {
@@ -216,16 +253,29 @@ int delay_line_enqueue(delay_line_t *dl, const void *pkt, size_t len)
       free(e);
       return -1;
    }
-   if (dl->head == NULL || dl_le(&e->release, &dl->head->release)) {
-      e->next = dl->head;
-      dl->head = e;
-      became_head = 1;
+
+   /* tfifo-style insert: O(1) tail append when in time order (the common case
+    * with constant delay), sorted insert from the head on jitter reordering. */
+   if (dl->tail == NULL || !dl_lt(&e->time_to_send, &dl->tail->time_to_send)) {
+      e->next = NULL;
+      if (dl->tail)
+         dl->tail->next = e;
+      else
+         dl->head = e;
+      dl->tail = e;
+      became_head = (dl->head == e);   /* only the first packet wakes the thread */
    } else {
-      prev = dl->head;
-      while (prev->next && !dl_le(&e->release, &prev->next->release))
-         prev = prev->next;
-      e->next = prev->next;
-      prev->next = e;
+      if (dl_le(&e->time_to_send, &dl->head->time_to_send)) {
+         e->next = dl->head;
+         dl->head = e;
+         became_head = 1;
+      } else {
+         prev = dl->head;
+         while (prev->next && !dl_le(&e->time_to_send, &prev->next->time_to_send))
+            prev = prev->next;
+         e->next = prev->next;
+         prev->next = e;
+      }
    }
    dl->count++;
    pthread_mutex_unlock(&dl->lock);

--- a/src/delay_line.c
+++ b/src/delay_line.c
@@ -359,6 +359,15 @@ int delay_line_enqueue(delay_line_t *dl, const void *pkt, size_t len)
    return 0;
 }
 
+int delay_line_config(delay_line_t *dl, int *latency_ms, int *jitter_ms)
+{
+   if (dl == NULL)
+      return 0;
+   *latency_ms = dl->base_latency_ms;
+   *jitter_ms = dl->jitter_ms;
+   return 1;
+}
+
 void delay_line_destroy(delay_line_t *dl)
 {
    dl_entry_t *e, *next;

--- a/src/delay_line.c
+++ b/src/delay_line.c
@@ -41,7 +41,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
+#include <math.h>
 #include <time.h>
 #include <pthread.h>
 
@@ -56,6 +58,17 @@
  * DL_LIMIT_DEFAULT packets under overload. */
 #define DL_LIMIT_DEFAULT 1000
 
+/* Gaussian (normal) jitter. table[i] = round(standard-normal quantile at
+ * (i+0.5)/DL_DIST_SIZE) * DL_DIST_SCALE, so a uniform index lookup scaled by
+ * sigma/DL_DIST_SCALE yields a normal sample with std ~sigma — the same idea
+ * as the distribution table tc passes to kernel netem for `distribution normal`
+ * (net/sched/sch_netem.c tabledist(), the dist!=NULL path). Generated once. */
+#define DL_DIST_SIZE  1024
+#define DL_DIST_SCALE 4096
+
+static int16_t g_dist_table[DL_DIST_SIZE];
+static pthread_once_t g_dist_once = PTHREAD_ONCE_INIT;
+
 /* One queued packet. The queue is kept ordered by time_to_send (earliest first),
  * with a tail pointer for netem's tfifo O(1) fast path. */
 typedef struct dl_entry {
@@ -68,6 +81,8 @@ typedef struct dl_entry {
 struct delay_line {
    int base_latency_ms;             /* mu  — netem latency */
    int jitter_ms;                   /* sigma — netem jitter */
+   const int16_t *dist_table;       /* normal-distribution table (shared) */
+   int dist_size;
    delay_send_fn send_fn;
    void *send_ctx;
    clockid_t clock;                 /* clock used for time_to_send + cond */
@@ -114,13 +129,65 @@ static int dl_le(const struct timespec *a, const struct timespec *b)
    return a->tv_nsec <= b->tv_nsec;
 }
 
-/* tabledist — netem's delay+jitter draw (the dist == NULL path from
- * sch_netem.c): uniform in [mu-sigma, mu+sigma]. This is the kernel netem
- * behaviour when tc supplies no distribution table. */
-static long dl_tabledist(long mu, long sigma)
+/* Peter Acklam's rational approximation of the standard-normal quantile
+ * (inverse CDF); accurate to ~1e-9 across (0,1). */
+static double dl_norm_quantile(double p)
+{
+   static const double a[] = { -3.969683028665376e+01, 2.209460984245205e+02,
+      -2.759285104469687e+02, 1.383577518672690e+02, -3.066479806614716e+01,
+      2.506628277459239e+00 };
+   static const double b[] = { -5.447609879822406e+01, 1.615858368580409e+02,
+      -1.556989798598866e+02, 6.680131188771972e+01, -1.328068155288572e+01 };
+   static const double c[] = { -7.784894002430293e-03, -3.223964580411365e-01,
+      -2.400758277161838e+00, -2.549732539343734e+00, 4.374664141464968e+00,
+      2.938163982698783e+00 };
+   static const double d[] = { 7.784695709041462e-03, 3.224671290700398e-01,
+      2.445134137142996e+00, 3.754408661907416e+00 };
+   const double plow = 0.02425, phigh = 1.0 - plow;
+   double q, r;
+
+   if (p < plow) {
+      q = sqrt(-2.0 * log(p));
+      return (((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5]) /
+             ((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1.0);
+   } else if (p <= phigh) {
+      q = p - 0.5;
+      r = q*q;
+      return (((((a[0]*r+a[1])*r+a[2])*r+a[3])*r+a[4])*r+a[5])*q /
+             (((((b[0]*r+b[1])*r+b[2])*r+b[3])*r+b[4])*r+1.0);
+   } else {
+      q = sqrt(-2.0 * log(1.0 - p));
+      return -(((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5]) /
+              ((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1.0);
+   }
+}
+
+/* Fill the shared normal-distribution table once (inverse-CDF sampling). */
+static void dl_init_dist(void)
+{
+   int i;
+   for (i = 0; i < DL_DIST_SIZE; i++) {
+      double q = dl_norm_quantile((i + 0.5) / (double)DL_DIST_SIZE);
+      long v = (long)(q * DL_DIST_SCALE + (q >= 0 ? 0.5 : -0.5));  /* round */
+      if (v > 32767) v = 32767;
+      if (v < -32768) v = -32768;
+      g_dist_table[i] = (int16_t)v;
+   }
+}
+
+/* tabledist — netem's delay+jitter draw. With a distribution table (the default
+ * here) it is Gaussian (normal), matching `tc netem delay Xms Yms`; without one
+ * it falls back to kernel netem's uniform [mu-sigma, mu+sigma] (dist==NULL). */
+static long dl_tabledist(long mu, long sigma, const int16_t *dist, int dist_size)
 {
    if (sigma == 0)
       return mu;
+   if (dist != NULL && dist_size > 0) {
+      /* (table[idx]/scale) is a standard-normal sample, so sigma*that has
+       * std ~sigma and the result is N(mu, sigma^2). */
+      long t = dist[(unsigned)random() % dist_size];
+      return mu + (sigma * t) / DL_DIST_SCALE;
+   }
    return (long)(random() % (2 * (unsigned long)sigma)) + mu - sigma;
 }
 
@@ -173,6 +240,9 @@ delay_line_t *delay_line_create(int base_latency_ms, int jitter_ms,
    memset(dl, 0, sizeof(*dl));
    dl->base_latency_ms = base_latency_ms;
    dl->jitter_ms = jitter_ms;
+   pthread_once(&g_dist_once, dl_init_dist);
+   dl->dist_table = g_dist_table;
+   dl->dist_size = DL_DIST_SIZE;
    dl->send_fn = send_fn;
    dl->send_ctx = send_ctx;
    dl->head = dl->tail = NULL;
@@ -233,7 +303,7 @@ int delay_line_enqueue(delay_line_t *dl, const void *pkt, size_t len)
    e->next = NULL;
 
    /* time_to_send = now + tabledist(latency, jitter) — netem's enqueue */
-   delay = dl_tabledist(dl->base_latency_ms, dl->jitter_ms);
+   delay = dl_tabledist(dl->base_latency_ms, dl->jitter_ms, dl->dist_table, dl->dist_size);
    if (delay < 0)
       delay = 0;
    dl_now(dl->clock, &t);

--- a/src/delay_line.c
+++ b/src/delay_line.c
@@ -28,6 +28,13 @@
 
 #define DL_MAX_PKT 65535   /* matches NIO_MAX_PKT_SIZE */
 
+/* Maximum packets buffered per direction before tail-drop. Mirrors the kernel
+ * netem default (NETEM_LIMIT_DEFAULT = 1000) so the user-space delay line, like
+ * netem, bounds memory and sheds excess load instead of buffering it without
+ * limit. Every delivered packet transits this queue, so delivery is capped at
+ * DL_LIMIT_DEFAULT packets under overload. */
+#define DL_LIMIT_DEFAULT 1000
+
 /* One queued packet. The list is kept ordered by release (earliest first). */
 typedef struct dl_entry {
    struct timespec release;        /* absolute time the packet becomes due */
@@ -45,6 +52,8 @@ struct delay_line {
    pthread_mutex_t lock;
    pthread_cond_t cond;            /* signaled when head changes or on stop */
    dl_entry_t *head;               /* earliest-release entry, or NULL */
+   int count;                      /* packets currently queued */
+   int limit;                      /* max queued before tail-drop (netem-like) */
    int stop;                       /* set by delay_line_destroy */
    pthread_t release_tid;
 };
@@ -96,6 +105,7 @@ static void *delay_release_thread(void *arg)
          /* due now: pop and send outside the lock so enqueue can proceed */
          e = dl->head;
          dl->head = e->next;
+         dl->count--;
          pthread_mutex_unlock(&dl->lock);
          dl->send_fn(dl->send_ctx, e->pkt, e->len);
          free(e);
@@ -125,6 +135,20 @@ delay_line_t *delay_line_create(int base_latency_ms, int jitter_ms,
    dl->send_fn = send_fn;
    dl->send_ctx = send_ctx;
    dl->head = NULL;
+   dl->count = 0;
+   dl->limit = DL_LIMIT_DEFAULT;
+
+   /* Optional override (UBRIDGE_DELAY_LIMIT packets). Mirrors netem's
+    * configurable limit without needing a protocol/filter-arg change. */
+   {
+      const char *s = getenv("UBRIDGE_DELAY_LIMIT");
+      if (s != NULL) {
+         long v = strtol(s, NULL, 10);
+         if (v > 0)
+            dl->limit = (int)v;
+      }
+   }
+
    dl->stop = 0;
 
    pthread_mutex_init(&dl->lock, NULL);
@@ -185,6 +209,13 @@ int delay_line_enqueue(delay_line_t *dl, const void *pkt, size_t len)
       free(e);
       return -1;
    }
+   if (dl->count >= dl->limit) {
+      /* queue full: tail-drop the newest packet so excess load is shed (like
+       * netem's limit) instead of buffering it without bound. */
+      pthread_mutex_unlock(&dl->lock);
+      free(e);
+      return -1;
+   }
    if (dl->head == NULL || dl_le(&e->release, &dl->head->release)) {
       e->next = dl->head;
       dl->head = e;
@@ -196,6 +227,7 @@ int delay_line_enqueue(delay_line_t *dl, const void *pkt, size_t len)
       e->next = prev->next;
       prev->next = e;
    }
+   dl->count++;
    pthread_mutex_unlock(&dl->lock);
 
    /* wake the release thread only when the earliest deadline moved up */

--- a/src/delay_line.h
+++ b/src/delay_line.h
@@ -1,0 +1,64 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2017 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DELAY_LINE_H_
+#define DELAY_LINE_H_
+
+#include <sys/types.h>
+#include <stddef.h>
+#include <time.h>
+
+/*
+ * A bounded-latency delay line.
+ *
+ * Each enqueued packet is held for (base_latency_ms +/- jitter_ms) and then
+ * handed to send_fn. Enqueueing never blocks the caller: a dedicated release
+ * thread owns the wait + send, so the receive loop that feeds the delay line
+ * stays drained and per-packet latency stays bounded regardless of offered
+ * load (see GNS3/ubridge#114 — the old delay filter slept inline in the
+ * bridge thread, serializing each direction to ~1000/latency pps).
+ *
+ * One delay_line belongs to one direction of one bridge (it is created and
+ * destroyed inside a single bridge_nios() call), so it is single-producer
+ * (the recv thread) / single-consumer (the release thread).
+ */
+
+typedef struct delay_line delay_line_t;
+
+/* Invoked by the release thread when a packet becomes due. ctx is the opaque
+ * pointer passed to delay_line_create() (the transmitting NIO). Returns
+ * whatever the underlying send returns. */
+typedef ssize_t (*delay_send_fn)(void *ctx, const void *pkt, size_t len);
+
+/* Create a delay line and start its release thread. Returns NULL on failure. */
+delay_line_t *delay_line_create(int base_latency_ms, int jitter_ms,
+                                delay_send_fn send_fn, void *send_ctx);
+
+/* Enqueue one packet for delayed release. The packet is copied, so the caller
+ * may reuse/free it immediately. Returns 0 on success, -1 on allocation
+ * failure (the caller should treat the packet as dropped). */
+int delay_line_enqueue(delay_line_t *dl, const void *pkt, size_t len);
+
+/* Stop the release thread, join it, and free the delay line and any packets
+ * still queued (they are dropped, not sent). Cancel-safe: may run from a
+ * pthread cleanup handler. */
+void delay_line_destroy(delay_line_t *dl);
+
+#endif /* !DELAY_LINE_H_ */

--- a/src/delay_line.h
+++ b/src/delay_line.h
@@ -35,6 +35,11 @@
  * load (see GNS3/ubridge#114 — the old delay filter slept inline in the
  * bridge thread, serializing each direction to ~1000/latency pps).
  *
+ * The queue is also depth-bounded (default 1000 packets, matching the kernel
+ * netem limit): once full, new packets are tail-dropped so memory stays
+ * bounded and excess load is shed rather than buffered. Every delivered packet
+ * transits this queue, so delivery is capped at the limit under overload.
+ *
  * One delay_line belongs to one direction of one bridge (it is created and
  * destroyed inside a single bridge_nios() call), so it is single-producer
  * (the recv thread) / single-consumer (the release thread).

--- a/src/delay_line.h
+++ b/src/delay_line.h
@@ -61,6 +61,11 @@ delay_line_t *delay_line_create(int base_latency_ms, int jitter_ms,
  * failure (the caller should treat the packet as dropped). */
 int delay_line_enqueue(delay_line_t *dl, const void *pkt, size_t len);
 
+/* If dl is non-NULL, copy its configured latency/jitter (ms) into the out args
+ * and return TRUE; otherwise return FALSE. Lets a caller detect a config change
+ * without keeping a parallel copy of the values. */
+int delay_line_config(delay_line_t *dl, int *latency_ms, int *jitter_ms);
+
 /* Stop the release thread, join it, and free the delay line and any packets
  * still queued (they are dropped, not sent). Cancel-safe: may run from a
  * pthread cleanup handler. */

--- a/src/hypervisor_iol_bridge.c
+++ b/src/hypervisor_iol_bridge.c
@@ -245,12 +245,18 @@ void *iol_bridge_listener(void *data)
 
        /* Send on the packet, minus the IOL header */
        bytes_received -= IOL_HDR_SIZE;
-       nio = bridge->port_table[port].destination_nio;
 
         /* filter the packet if there is a filter configured; snapshot the
-         * delay config under the same lock the hypervisor mutates the list with */
+         * delay config under the same lock the hypervisor mutates the list with.
+         * Re-validate destination_nio under the lock: it may have been set to
+         * NULL by cmd_delete_nio_udp while we were blocked in read(). */
        int have_delay = FALSE, lat_ms = 0, jit_ms = 0;
        pthread_mutex_lock(&global_lock);
+       nio = bridge->port_table[port].destination_nio;
+       if (nio == NULL) {
+            pthread_mutex_unlock(&global_lock);
+            continue;
+       }
        if (bridge->port_table[port].packet_filters != NULL) {
             packet_filter_t *filter = bridge->port_table[port].packet_filters;
             packet_filter_t *next;
@@ -775,8 +781,14 @@ static int create_iol_port_entry(hypervisor_conn_t *conn, iol_bridge_t *bridge, 
       pthread_cancel(iol_nio->tid);
       pthread_join(iol_nio->tid, NULL);
       iol_nio->tid = 0;
-      delay_line_destroy(iol_nio->delay_line_nio);
-      delay_line_destroy(iol_nio->delay_line_iol);
+      /* NULL the delay-line pointers before destroy — see
+       * cmd_delete_nio_udp for the rationale. */
+      delay_line_t *old_nio = iol_nio->delay_line_nio;
+      iol_nio->delay_line_nio = NULL;
+      delay_line_t *old_iol = iol_nio->delay_line_iol;
+      iol_nio->delay_line_iol = NULL;
+      delay_line_destroy(old_nio);
+      delay_line_destroy(old_iol);
       free_pcap_capture(iol_nio->capture);
       free_packet_filters(iol_nio->packet_filters);
       free_nio(iol_nio->destination_nio);
@@ -858,8 +870,16 @@ static int cmd_delete_nio_udp(hypervisor_conn_t *conn, int argc, char *argv[])
       pthread_cancel(iol_nio->tid);
       pthread_join(iol_nio->tid, NULL);
       iol_nio->tid = 0;
-      delay_line_destroy(iol_nio->delay_line_nio);
-      delay_line_destroy(iol_nio->delay_line_iol);
+      /* NULL the delay-line pointers before destroy so the IOL bridge
+       * listener (IOL -> NIO direction) sees NULL if it concurrently
+       * accesses them through port_table, and delay_line_destroy(NULL)
+       * is a safe no-op. */
+      delay_line_t *old_nio = iol_nio->delay_line_nio;
+      iol_nio->delay_line_nio = NULL;
+      delay_line_t *old_iol = iol_nio->delay_line_iol;
+      iol_nio->delay_line_iol = NULL;
+      delay_line_destroy(old_nio);
+      delay_line_destroy(old_iol);
       free_pcap_capture(iol_nio->capture);
       free_packet_filters(iol_nio->packet_filters);
       free_nio(iol_nio->destination_nio);
@@ -1060,9 +1080,15 @@ static int cmd_reset_packet_filters(hypervisor_conn_t *conn, int argc, char *arg
    }
 
    /* dropping the filters also drops any in-flight delay; tear down the lines
-    * so packets don't keep releasing against a config that no longer exists */
-   delay_line_destroy(iol_nio->delay_line_nio);
-   delay_line_destroy(iol_nio->delay_line_iol);
+    * so packets don't keep releasing against a config that no longer exists.
+    * NULL the pointers before destroy so the bridge listener sees NULL
+    * if it concurrently accesses them through port_table. */
+   delay_line_t *old_nio = iol_nio->delay_line_nio;
+   iol_nio->delay_line_nio = NULL;
+   delay_line_t *old_iol = iol_nio->delay_line_iol;
+   iol_nio->delay_line_iol = NULL;
+   delay_line_destroy(old_nio);
+   delay_line_destroy(old_iol);
    free_packet_filters(iol_nio->packet_filters);
    iol_nio->packet_filters = NULL;
 

--- a/src/hypervisor_iol_bridge.c
+++ b/src/hypervisor_iol_bridge.c
@@ -33,8 +33,69 @@
 #include "hypervisor_iol_bridge.h"
 #include "pcap_capture.h"
 #include "packet_filter.h"
+#include "delay_line.h"
 
 iol_bridge_t *iol_bridge_list = NULL;
+
+/* ---- delay line send callbacks (one per IOL direction) ---- */
+
+/* NIO -> IOL: prepend the port's pre-calculated IOL header and sendto the
+ * IOL instance. ctx = the port's iol_nio_t. */
+static ssize_t iol_sendto_iol_cb(void *ctx, const void *pkt, size_t len)
+{
+   iol_nio_t *iol_nio = ctx;
+   unsigned char buf[IOL_HDR_SIZE + MAX_MTU];
+
+   if (len > MAX_MTU)
+      len = MAX_MTU;
+   memcpy(buf, iol_nio->header, IOL_HDR_SIZE);
+   memcpy(buf + IOL_HDR_SIZE, pkt, len);
+   return sendto(iol_nio->iol_bridge_sock, buf, len + IOL_HDR_SIZE, 0,
+                 (struct sockaddr *)&iol_nio->iol_sockaddr, sizeof(iol_nio->iol_sockaddr));
+}
+
+/* IOL -> NIO: forward via the destination NIO and account for it. ctx = nio. */
+static ssize_t iol_nio_send_cb(void *ctx, const void *pkt, size_t len)
+{
+   nio_t *nio = ctx;
+   ssize_t sent = nio_send(nio, (void *)pkt, len);
+
+   if (sent != -1) {
+      nio->packets_out++;
+      nio->bytes_out += sent;
+   }
+   return sent;
+}
+
+/* Lazily sync *dl to the delay config (have_delay / lat / jit, snapshotted by
+ * the caller under global_lock) and, if delaying, enqueue the packet. Returns
+ * TRUE if consumed (the caller must skip its inline send). */
+static int iol_delay_route(delay_line_t **dl, int have_delay, int lat, int jit,
+                           delay_send_fn fn, void *ctx,
+                           const void *pkt, size_t len, const char *name)
+{
+   int cur_lat = -1, cur_jit = -1;
+   delay_line_config(*dl, &cur_lat, &cur_jit);   /* current line's config, or -1 */
+
+   if (have_delay) {
+      if (*dl == NULL || lat != cur_lat || jit != cur_jit) {
+         delay_line_destroy(*dl);
+         *dl = delay_line_create(lat, jit, fn, ctx);
+         if (*dl == NULL)
+            fprintf(stderr, "IOL bridge '%s': could not create delay line, forwarding without delay\n", name);
+      }
+   } else if (*dl != NULL) {
+      delay_line_destroy(*dl);
+      *dl = NULL;
+   }
+
+   if (*dl) {
+      if (delay_line_enqueue(*dl, pkt, len) != 0 && debug_level > 0)
+         printf("Packet dropped by delay line on IOL bridge '%s'\n", name);
+      return TRUE;
+   }
+   return FALSE;
+}
 
 static iol_bridge_t *find_bridge(char *bridge_name)
 {
@@ -93,7 +154,10 @@ void *iol_nio_listener(void *data)
                dump_packet(stdout, &pkt[IOL_HDR_SIZE], bytes_received);
         }
 
-        /* filter the packet if there is a filter configured */
+        /* filter the packet if there is a filter configured; snapshot the
+         * delay config under the same lock the hypervisor mutates the list with */
+        int have_delay = FALSE, lat_ms = 0, jit_ms = 0;
+        pthread_mutex_lock(&global_lock);
         if (iol_nio->packet_filters != NULL) {
              packet_filter_t *filter = iol_nio->packet_filters;
              packet_filter_t *next;
@@ -108,12 +172,20 @@ void *iol_nio_listener(void *data)
                  filter = next;
              }
          }
+        have_delay = packet_filter_get_delay(iol_nio->packet_filters, &lat_ms, &jit_ms);
+        pthread_mutex_unlock(&global_lock);
 
         if (drop_packet == TRUE)
            continue;
 
         /* Dump the packet to a PCAP file if capture is activated */
         pcap_capture_packet(iol_nio->capture, &pkt[IOL_HDR_SIZE], bytes_received);
+
+        /* route through the NIO->IOL delay line if a delay filter is set */
+        if (iol_delay_route(&iol_nio->delay_line_nio, have_delay, lat_ms, jit_ms,
+                            iol_sendto_iol_cb, iol_nio,
+                            &pkt[IOL_HDR_SIZE], bytes_received, bridge->name))
+           continue;
 
         /* Add the length of the IOU header we'll be sending */
         bytes_received += IOL_HDR_SIZE;
@@ -175,7 +247,10 @@ void *iol_bridge_listener(void *data)
        bytes_received -= IOL_HDR_SIZE;
        nio = bridge->port_table[port].destination_nio;
 
-        /* filter the packet if there is a filter configured */
+        /* filter the packet if there is a filter configured; snapshot the
+         * delay config under the same lock the hypervisor mutates the list with */
+       int have_delay = FALSE, lat_ms = 0, jit_ms = 0;
+       pthread_mutex_lock(&global_lock);
        if (bridge->port_table[port].packet_filters != NULL) {
             packet_filter_t *filter = bridge->port_table[port].packet_filters;
             packet_filter_t *next;
@@ -190,6 +265,8 @@ void *iol_bridge_listener(void *data)
                 filter = next;
             }
        }
+       have_delay = packet_filter_get_delay(bridge->port_table[port].packet_filters, &lat_ms, &jit_ms);
+       pthread_mutex_unlock(&global_lock);
 
        if (drop_packet == TRUE)
           continue;
@@ -199,6 +276,12 @@ void *iol_bridge_listener(void *data)
 
        /* Destination NIO hasn't been created yet */
        if (nio == NULL)
+          continue;
+
+       /* route through the IOL->NIO delay line if a delay filter is set */
+       if (iol_delay_route(&bridge->port_table[port].delay_line_iol, have_delay, lat_ms, jit_ms,
+                           iol_nio_send_cb, nio,
+                           &pkt[IOL_HDR_SIZE], bytes_received, bridge->name))
           continue;
 
        bytes_sent = nio->send(nio->dptr, &pkt[IOL_HDR_SIZE], bytes_received);
@@ -406,6 +489,8 @@ static int cmd_create_bridge(hypervisor_conn_t *conn, int argc, char *argv[])
       new_bridge->port_table[i].destination_nio = NULL;
       new_bridge->port_table[i].capture = NULL;
       new_bridge->port_table[i].packet_filters = NULL;
+      new_bridge->port_table[i].delay_line_nio = NULL;
+      new_bridge->port_table[i].delay_line_iol = NULL;
    }
 
    new_bridge->next = *head;
@@ -433,11 +518,6 @@ static int cmd_delete_bridge(hypervisor_conn_t *conn, int argc, char *argv[])
           else
              prev->next = bridge->next;
 
-          close(bridge->iol_bridge_sock);
-          unlink(bridge->bridge_sockaddr.sun_path);
-          if ((unlock_unix_socket(bridge->sock_lock, bridge->bridge_sockaddr.sun_path)) == -1)
-              fprintf(stderr, "failed to unlock %s\n", bridge->bridge_sockaddr.sun_path);
-
           if (bridge->running) {
              pthread_cancel(bridge->bridge_tid);
              pthread_join(bridge->bridge_tid, NULL);
@@ -448,6 +528,8 @@ static int cmd_delete_bridge(hypervisor_conn_t *conn, int argc, char *argv[])
                     pthread_cancel(bridge->port_table[i].tid);
                     pthread_join(bridge->port_table[i].tid, NULL);
                     bridge->port_table[i].tid = 0;
+                    delay_line_destroy(bridge->port_table[i].delay_line_nio);
+                    delay_line_destroy(bridge->port_table[i].delay_line_iol);
                     free_pcap_capture(bridge->port_table[i].capture);
                     free_packet_filters(bridge->port_table[i].packet_filters);
                     free_nio(bridge->port_table[i].destination_nio);
@@ -455,6 +537,13 @@ static int cmd_delete_bridge(hypervisor_conn_t *conn, int argc, char *argv[])
              }
              free(bridge->port_table);
           }
+
+          /* close after delay lines are torn down (their release threads
+           * sendto this socket) */
+          close(bridge->iol_bridge_sock);
+          unlink(bridge->bridge_sockaddr.sun_path);
+          if ((unlock_unix_socket(bridge->sock_lock, bridge->bridge_sockaddr.sun_path)) == -1)
+              fprintf(stderr, "failed to unlock %s\n", bridge->bridge_sockaddr.sun_path);
           if (bridge->name)
              free(bridge->name);
           free(bridge);
@@ -686,6 +775,8 @@ static int create_iol_port_entry(hypervisor_conn_t *conn, iol_bridge_t *bridge, 
       pthread_cancel(iol_nio->tid);
       pthread_join(iol_nio->tid, NULL);
       iol_nio->tid = 0;
+      delay_line_destroy(iol_nio->delay_line_nio);
+      delay_line_destroy(iol_nio->delay_line_iol);
       free_pcap_capture(iol_nio->capture);
       free_packet_filters(iol_nio->packet_filters);
       free_nio(iol_nio->destination_nio);
@@ -767,6 +858,8 @@ static int cmd_delete_nio_udp(hypervisor_conn_t *conn, int argc, char *argv[])
       pthread_cancel(iol_nio->tid);
       pthread_join(iol_nio->tid, NULL);
       iol_nio->tid = 0;
+      delay_line_destroy(iol_nio->delay_line_nio);
+      delay_line_destroy(iol_nio->delay_line_iol);
       free_pcap_capture(iol_nio->capture);
       free_packet_filters(iol_nio->packet_filters);
       free_nio(iol_nio->destination_nio);
@@ -893,10 +986,6 @@ static int cmd_add_packet_filter(hypervisor_conn_t *conn, int argc, char *argv[]
       return (-1);
    }
 
-   if (!strcmp(argv[4], "delay")) {
-      hypervisor_send_reply(conn, HSC_ERR_CREATE, 1, "delay filter is not supported on IOL bridges");
-      return (-1);
-   }
    res = add_packet_filter(&iol_nio->packet_filters, argv[3], argv[4], argc-5, &argv[5]);
    if (!res)
       hypervisor_send_reply(conn, HSC_INFO_OK, 1, "Filter '%s' type '%s' added to bridge '%s'", argv[3], argv[4], argv[0]);
@@ -970,6 +1059,10 @@ static int cmd_reset_packet_filters(hypervisor_conn_t *conn, int argc, char *arg
       return (-1);
    }
 
+   /* dropping the filters also drops any in-flight delay; tear down the lines
+    * so packets don't keep releasing against a config that no longer exists */
+   delay_line_destroy(iol_nio->delay_line_nio);
+   delay_line_destroy(iol_nio->delay_line_iol);
    free_packet_filters(iol_nio->packet_filters);
    iol_nio->packet_filters = NULL;
 

--- a/src/hypervisor_iol_bridge.c
+++ b/src/hypervisor_iol_bridge.c
@@ -893,6 +893,10 @@ static int cmd_add_packet_filter(hypervisor_conn_t *conn, int argc, char *argv[]
       return (-1);
    }
 
+   if (!strcmp(argv[4], "delay")) {
+      hypervisor_send_reply(conn, HSC_ERR_CREATE, 1, "delay filter is not supported on IOL bridges");
+      return (-1);
+   }
    res = add_packet_filter(&iol_nio->packet_filters, argv[3], argv[4], argc-5, &argv[5]);
    if (!res)
       hypervisor_send_reply(conn, HSC_INFO_OK, 1, "Filter '%s' type '%s' added to bridge '%s'", argv[3], argv[4], argv[0]);

--- a/src/hypervisor_iol_bridge.h
+++ b/src/hypervisor_iol_bridge.h
@@ -23,6 +23,7 @@
 
 #include <netinet/in.h>
 #include "ubridge.h"
+#include "delay_line.h"
 
 /* IOL header */
 
@@ -68,6 +69,8 @@ typedef struct
   struct sockaddr_un iol_sockaddr;
   nio_t *destination_nio;
   packet_filter_t *packet_filters;
+  delay_line_t *delay_line_nio;   /* NIO -> IOL direction delay line */
+  delay_line_t *delay_line_iol;   /* IOL -> NIO direction delay line */
   unsigned char header[IOL_HDR_SIZE];
   pcap_capture_t *capture;
   pthread_t tid;

--- a/src/packet_filter.c
+++ b/src/packet_filter.c
@@ -19,7 +19,6 @@
  */
 
 #include <string.h>
-#include <time.h>
 #include <pcap.h>
 #include "packet_filter.h"
 #include "pcap_filter.h"
@@ -184,24 +183,35 @@ static int delay_setup(void **opt, int argc, char *argv[])
    return (0);
 }
 
-/* Packet handler: add delay (latency and optionally jitter) */
+/* Packet handler: no-op. The configured latency is applied as a real delay
+ * line by bridge_nios() (see src/delay_line.c) so that delaying a packet
+ * never blocks the bridge thread. The old inline nanosleep() serialized each
+ * direction to ~1000/latency pps and collapsed links under load — see
+ * GNS3/ubridge#114. The latency/jitter values are read back via
+ * packet_filter_get_delay(). */
 static int delay_handler(void *pkt, size_t len, void *opt)
 {
-   struct delay_data *data = opt;
-   struct timespec ts;
-   int delay;
-
-   if (data != NULL) {
-      delay = data->latency;
-      if (data->jitter)
-         delay = (delay - data->jitter) + random() % ((delay + data->jitter + 1) - (delay - data->jitter));
-      if (delay < 0)
-          delay = 0;
-      ts.tv_sec = delay / 1000;
-      ts.tv_nsec = (delay % 1000) * 1000000;
-      nanosleep(&ts, NULL);
-   }
+   (void)pkt;
+   (void)len;
+   (void)opt;
    return (FILTER_ACTION_PASS);
+}
+
+/* Read the configured delay (ms) back out of the first delay filter, if any. */
+int packet_filter_get_delay(packet_filter_t *packet_filters, int *latency_ms, int *jitter_ms)
+{
+   packet_filter_t *filter = packet_filters;
+
+   while (filter != NULL) {
+      if (filter->type == FILTER_TYPE_DELAY && filter->data != NULL) {
+         struct delay_data *data = filter->data;
+         *latency_ms = data->latency;
+         *jitter_ms = data->jitter;
+         return (TRUE);
+      }
+      filter = filter->next;
+   }
+   return (FALSE);
 }
 
 /* Free resources used by filter */

--- a/src/packet_filter.h
+++ b/src/packet_filter.h
@@ -55,4 +55,10 @@ packet_filter_t *find_packet_filter(packet_filter_t *packet_filters, char *filte
 int delete_packet_filter(packet_filter_t **packet_filters, char *filter_name);
 void free_packet_filters(packet_filter_t *filter);
 
+/* If a delay filter is present, copy its latency/jitter (ms) into the out
+ * args and return TRUE; otherwise return FALSE. The delay filter no longer
+ * applies its latency inline (see packet_filter.c) — bridge_nios() reads the
+ * configured value via this accessor to drive a real delay line. */
+int packet_filter_get_delay(packet_filter_t *packet_filters, int *latency_ms, int *jitter_ms);
+
 #endif /* !FILTER_H_ */

--- a/src/ubridge.c
+++ b/src/ubridge.c
@@ -35,6 +35,7 @@
 #include "parse.h"
 #include "pcap_capture.h"
 #include "packet_filter.h"
+#include "delay_line.h"
 #include "hypervisor.h"
 #ifdef __linux__
 #include "hypervisor_iol_bridge.h"
@@ -46,11 +47,50 @@ bridge_t *bridge_list = NULL;
 int debug_level = 0;
 int hypervisor_mode = 0;
 
+/* Send callback for the delay line's release thread: forward a due packet out
+ * the transmitting NIO and account for it. (When no delay filter is present,
+ * bridge_nios sends inline instead and does this accounting itself.) */
+static ssize_t delay_send_cb(void *ctx, const void *pkt, size_t len)
+{
+   nio_t *tx_nio = ctx;
+   ssize_t bytes_sent;
+
+   bytes_sent = nio_send(tx_nio, (void *)pkt, len);
+   if (bytes_sent == -1) {
+      perror("send");
+      return -1;
+   }
+   tx_nio->packets_out++;
+   tx_nio->bytes_out += bytes_sent;
+   return bytes_sent;
+}
+
 static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
 {
   ssize_t bytes_received, bytes_sent;
   unsigned char pkt[NIO_MAX_PKT_SIZE];
   int drop_packet;
+  int latency_ms = 0, jitter_ms = 0;
+  delay_line_t *delay_line = NULL;
+  int rc = 0;
+
+  /* If a delay filter is configured, route the send through a real delay line
+   * instead of blocking this thread. The old delay handler slept inline,
+   * capping each direction at ~1000/latency pps and collapsing the link under
+   * load (GNS3/ubridge#114). The delay line's release thread owns the wait. */
+  if (packet_filter_get_delay(bridge->packet_filters, &latency_ms, &jitter_ms)) {
+      delay_line = delay_line_create(latency_ms, jitter_ms, delay_send_cb, tx_nio);
+      if (delay_line == NULL)
+         fprintf(stderr, "bridge '%s': could not create delay line, forwarding without delay\n", bridge->name);
+  }
+
+  /* Tear the delay line down on normal exit or pthread_cancel (bridges are
+   * stopped/deleted via pthread_cancel). delay_line_destroy() is a no-op on
+   * NULL, so we always push/pop — and we MUST: pthread_cleanup_push/pop are
+   * macros that open/close one block, so the loop has to live inside it.
+   * Guarding them with `if (delay_line)` would skip the whole loop when no
+   * delay filter is configured. */
+  pthread_cleanup_push((void (*)(void *))delay_line_destroy, delay_line);
 
   while (1) {
 
@@ -61,7 +101,8 @@ static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
         perror("recv");
         if (errno == ECONNREFUSED || errno == ENETDOWN)
            continue;
-        return -1;
+        rc = -1;
+        break;
     }
 
     if (bytes_received > NIO_MAX_PKT_SIZE) {
@@ -103,6 +144,14 @@ static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
     /* dump the packet to a PCAP file if capture is activated */
     pcap_capture_packet(bridge->capture, pkt, bytes_received);
 
+    if (delay_line) {
+        /* hand the packet to the release thread; never block the recv loop.
+         * On enqueue failure (out of memory) the packet is dropped. */
+        if (delay_line_enqueue(delay_line, pkt, bytes_received) != 0 && debug_level > 0)
+           printf("Packet dropped by delay line on bridge '%s'\n", bridge->name);
+        continue;
+    }
+
     /* send what we received to the transmitting NIO */
     bytes_sent = nio_send(tx_nio, pkt, bytes_received);
     if (bytes_sent == -1) {
@@ -117,13 +166,19 @@ static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
         if (tx_nio->type == NIO_TYPE_TAP && errno == EIO)
             continue;
 
-        return -1;
+        rc = -1;
+        break;
     }
 
     tx_nio->packets_out++;
     tx_nio->bytes_out += bytes_sent;
   }
-  return 0;
+
+  /* runs delay_line_destroy (no-op when no delay filter), joining the release
+   * thread and freeing any queued packets. On pthread_cancel the cleanup
+   * stack runs it instead and this line is never reached. */
+  pthread_cleanup_pop(1);
+  return rc;
 }
 
 /* Source NIO thread */

--- a/src/ubridge.c
+++ b/src/ubridge.c
@@ -122,7 +122,11 @@ static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
             dump_packet(stdout, pkt, bytes_received);
     }
 
-    /* filter the packet if there is a filter configured */
+    int have_delay;
+
+    /* Lock the shared filter list while we walk it — the hypervisor thread
+     * mutates it via add/delete/reset_packet_filter under global_lock too. */
+    pthread_mutex_lock(&global_lock);
     if (bridge->packet_filters != NULL) {
          packet_filter_t *filter = bridge->packet_filters;
          packet_filter_t *next;
@@ -137,6 +141,9 @@ static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
              filter = next;
          }
      }
+    /* snapshot the delay config while the list is stable */
+    have_delay = packet_filter_get_delay(bridge->packet_filters, &latency_ms, &jitter_ms);
+    pthread_mutex_unlock(&global_lock);
 
     if (drop_packet == TRUE)
        continue;
@@ -144,10 +151,9 @@ static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
     /* dump the packet to a PCAP file if capture is activated */
     pcap_capture_packet(bridge->capture, pkt, bytes_received);
 
-    /* (re)sync the delay line to the currently-configured delay filter, if any.
-     * Recreate only when it appears, disappears, or its latency/jitter change;
-     * in steady state this is just one cheap scan of the (short) filter list. */
-    if (packet_filter_get_delay(bridge->packet_filters, &latency_ms, &jitter_ms)) {
+    /* (re)sync the delay line using the snapshotted config — create/destroy
+     * outside the lock so a join inside destroy doesn't block other bridges. */
+    if (have_delay) {
         if (delay_line == NULL || latency_ms != cur_latency || jitter_ms != cur_jitter) {
             delay_line_t *old = delay_line;
             delay_line = NULL;                 /* visible as NULL to a cancel-time cleanup */

--- a/src/ubridge.c
+++ b/src/ubridge.c
@@ -65,32 +65,32 @@ static ssize_t delay_send_cb(void *ctx, const void *pkt, size_t len)
    return bytes_sent;
 }
 
+/* pthread cleanup helper: destroy whichever delay line is currently active.
+ * bridge_nios() reassigns its local `delay_line` as filters come and go, so
+ * the handler reads it through a pointer-to-pointer — capturing the pointer's
+ * value at push time would go stale when the line is recreated. */
+static void delay_line_destroy_indir(void *arg)
+{
+   delay_line_destroy(*(delay_line_t **)arg);
+}
+
 static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
 {
   ssize_t bytes_received, bytes_sent;
   unsigned char pkt[NIO_MAX_PKT_SIZE];
   int drop_packet;
   int latency_ms = 0, jitter_ms = 0;
+  int cur_latency = -1, cur_jitter = -1;   /* delay config currently applied */
   delay_line_t *delay_line = NULL;
   int rc = 0;
 
-  /* If a delay filter is configured, route the send through a real delay line
-   * instead of blocking this thread. The old delay handler slept inline,
-   * capping each direction at ~1000/latency pps and collapsing the link under
-   * load (GNS3/ubridge#114). The delay line's release thread owns the wait. */
-  if (packet_filter_get_delay(bridge->packet_filters, &latency_ms, &jitter_ms)) {
-      delay_line = delay_line_create(latency_ms, jitter_ms, delay_send_cb, tx_nio);
-      if (delay_line == NULL)
-         fprintf(stderr, "bridge '%s': could not create delay line, forwarding without delay\n", bridge->name);
-  }
-
-  /* Tear the delay line down on normal exit or pthread_cancel (bridges are
-   * stopped/deleted via pthread_cancel). delay_line_destroy() is a no-op on
-   * NULL, so we always push/pop — and we MUST: pthread_cleanup_push/pop are
-   * macros that open/close one block, so the loop has to live inside it.
-   * Guarding them with `if (delay_line)` would skip the whole loop when no
-   * delay filter is configured. */
-  pthread_cleanup_push((void (*)(void *))delay_line_destroy, delay_line);
+  /* The delay line is managed lazily inside the loop, not created once at
+   * start: GNS3 starts the bridge first and applies packet filters only
+   * afterwards (gns3-server add_ubridge_udp_connection: `bridge start` then
+   * `_ubridge_apply_filters`), and filters can be reset/re-added at runtime.
+   * So we re-read the delay config on each packet and (re)create/destroy the
+   * line to match. delay_line always holds the current line or NULL. */
+  pthread_cleanup_push(delay_line_destroy_indir, &delay_line);
 
   while (1) {
 
@@ -144,9 +144,30 @@ static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
     /* dump the packet to a PCAP file if capture is activated */
     pcap_capture_packet(bridge->capture, pkt, bytes_received);
 
+    /* (re)sync the delay line to the currently-configured delay filter, if any.
+     * Recreate only when it appears, disappears, or its latency/jitter change;
+     * in steady state this is just one cheap scan of the (short) filter list. */
+    if (packet_filter_get_delay(bridge->packet_filters, &latency_ms, &jitter_ms)) {
+        if (delay_line == NULL || latency_ms != cur_latency || jitter_ms != cur_jitter) {
+            delay_line_t *old = delay_line;
+            delay_line = NULL;                 /* visible as NULL to a cancel-time cleanup */
+            delay_line_destroy(old);
+            delay_line = delay_line_create(latency_ms, jitter_ms, delay_send_cb, tx_nio);
+            cur_latency = latency_ms;
+            cur_jitter = jitter_ms;
+            if (delay_line == NULL)
+               fprintf(stderr, "bridge '%s': could not create delay line, forwarding without delay\n", bridge->name);
+        }
+    } else if (delay_line != NULL) {
+        delay_line_t *old = delay_line;
+        delay_line = NULL;
+        delay_line_destroy(old);
+        cur_latency = cur_jitter = -1;
+    }
+
     if (delay_line) {
         /* hand the packet to the release thread; never block the recv loop.
-         * On enqueue failure (out of memory) the packet is dropped. */
+         * On enqueue failure (out of memory or queue full) the packet is dropped. */
         if (delay_line_enqueue(delay_line, pkt, bytes_received) != 0 && debug_level > 0)
            printf("Packet dropped by delay line on bridge '%s'\n", bridge->name);
         continue;

--- a/src/ubridge.c
+++ b/src/ubridge.c
@@ -80,7 +80,6 @@ static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
   unsigned char pkt[NIO_MAX_PKT_SIZE];
   int drop_packet;
   int latency_ms = 0, jitter_ms = 0;
-  int cur_latency = -1, cur_jitter = -1;   /* delay config currently applied */
   delay_line_t *delay_line = NULL;
   int rc = 0;
 
@@ -153,22 +152,23 @@ static int bridge_nios(nio_t *rx_nio, nio_t *tx_nio, bridge_t *bridge)
 
     /* (re)sync the delay line using the snapshotted config — create/destroy
      * outside the lock so a join inside destroy doesn't block other bridges. */
-    if (have_delay) {
-        if (delay_line == NULL || latency_ms != cur_latency || jitter_ms != cur_jitter) {
-            delay_line_t *old = delay_line;
-            delay_line = NULL;                 /* visible as NULL to a cancel-time cleanup */
-            delay_line_destroy(old);
-            delay_line = delay_line_create(latency_ms, jitter_ms, delay_send_cb, tx_nio);
-            cur_latency = latency_ms;
-            cur_jitter = jitter_ms;
-            if (delay_line == NULL)
-               fprintf(stderr, "bridge '%s': could not create delay line, forwarding without delay\n", bridge->name);
-        }
-    } else if (delay_line != NULL) {
-        delay_line_t *old = delay_line;
-        delay_line = NULL;
-        delay_line_destroy(old);
-        cur_latency = cur_jitter = -1;
+    {
+       int cur_lat = -1, cur_jit = -1;
+       delay_line_config(delay_line, &cur_lat, &cur_jit);  /* current line's config, or -1 */
+       if (have_delay) {
+          if (delay_line == NULL || latency_ms != cur_lat || jitter_ms != cur_jit) {
+             delay_line_t *old = delay_line;
+             delay_line = NULL;                 /* visible as NULL to a cancel-time cleanup */
+             delay_line_destroy(old);
+             delay_line = delay_line_create(latency_ms, jitter_ms, delay_send_cb, tx_nio);
+             if (delay_line == NULL)
+                fprintf(stderr, "bridge '%s': could not create delay line, forwarding without delay\n", bridge->name);
+          }
+       } else if (delay_line != NULL) {
+          delay_line_t *old = delay_line;
+          delay_line = NULL;
+          delay_line_destroy(old);
+       }
     }
 
     if (delay_line) {
@@ -275,11 +275,6 @@ static void free_iol_bridges(iol_bridge_t *bridge)
     if (bridge->name)
        free(bridge->name);
 
-    close(bridge->iol_bridge_sock);
-    unlink(bridge->bridge_sockaddr.sun_path);
-    if ((unlock_unix_socket(bridge->sock_lock, bridge->bridge_sockaddr.sun_path)) == -1)
-       fprintf(stderr, "failed to unlock %s\n", bridge->bridge_sockaddr.sun_path);
-
     if (bridge->running) {
        pthread_cancel(bridge->bridge_tid);
        pthread_join(bridge->bridge_tid, NULL);
@@ -290,6 +285,10 @@ static void free_iol_bridges(iol_bridge_t *bridge)
               pthread_cancel(bridge->port_table[i].tid);
               pthread_join(bridge->port_table[i].tid, NULL);
               bridge->port_table[i].tid = 0;
+              /* destroy delay lines (joins their release threads) before
+               * freeing the NIO / closing the IOL socket they send through */
+              delay_line_destroy(bridge->port_table[i].delay_line_nio);
+              delay_line_destroy(bridge->port_table[i].delay_line_iol);
               free_pcap_capture(bridge->port_table[i].capture);
               free_packet_filters(bridge->port_table[i].packet_filters);
               free_nio(bridge->port_table[i].destination_nio);
@@ -297,6 +296,13 @@ static void free_iol_bridges(iol_bridge_t *bridge)
        }
        free(bridge->port_table);
     }
+
+    /* close after delay lines are torn down: their release threads sendto
+     * this socket, so they must be joined first */
+    close(bridge->iol_bridge_sock);
+    unlink(bridge->bridge_sockaddr.sun_path);
+    if ((unlock_unix_socket(bridge->sock_lock, bridge->bridge_sockaddr.sun_path)) == -1)
+       fprintf(stderr, "failed to unlock %s\n", bridge->bridge_sockaddr.sun_path);
 
     next = bridge->next;
     free(bridge);

--- a/tests/delay/README.md
+++ b/tests/delay/README.md
@@ -32,6 +32,24 @@ UDP NIOs (looped back to receiver sockets under the test's control) and a
    excess packets are tail-dropped, so memory stays bounded while latency
    stays bounded. Uses `UBRIDGE_DELAY_LIMIT=20` for a deterministic check.
 
+`test_perf.py`:
+
+1. **large burst** — 400 packets @50ms drain in bounded time with little loss
+   (the serial-sleep bug took ~20s; the delay line ~50ms).
+2. **delay accuracy** — measured ~= configured across 10/100/500 ms.
+3. **no-delay baseline** — the fast path forwards a burst quickly (regression
+   guard; sized to the kernel UDP buffer).
+
+`test_boundary.py`:
+
+1. **minimum latency** (1 ms; setup rejects <= 0).
+2. **jitter > latency** — negative draws clamp to 0, no crash.
+3. **packet sizes** — 1-byte and ~60 KB packets traverse the delay line.
+4. **stop with queued packets** — tearing down a bridge mid-delay doesn't hang
+   (joins the release thread, frees the queue) and ubridge stays responsive.
+5. **limit boundary** — with `UBRIDGE_DELAY_LIMIT=10`, exactly 10 are delivered
+   whether 10 or 11 are sent (the tail-drop edge).
+
 ## Tuning
 
 The per-direction queue depth defaults to 1000 packets (same as netem's

--- a/tests/delay/README.md
+++ b/tests/delay/README.md
@@ -1,0 +1,47 @@
+# delay filter tests
+
+Regression coverage for the `delay` packet filter, which had a structural
+flaw (GNS3/ubridge#114, root cause of gns3/gns3-server#2827):
+
+> the filter slept inline in the per-direction bridge thread (`nanosleep`),
+> so each direction serviced at most ~`1000/latency` pps. Any heavier load
+> backed up in the kernel UDP buffer, RTT climbed without bound, and the link
+> collapsed with packet loss.
+
+The fix routes delayed sends through a real delay line
+(`src/delay_line.[ch]`) with a dedicated release thread, so the receive loop
+never blocks and per-packet latency stays bounded regardless of offered load.
+
+## What is checked
+
+`test_latency.py` drives ubridge's hypervisor protocol with a bridge of two
+UDP NIOs (looped back to receiver sockets under the test's control) and a
+`delay` filter:
+
+1. **single-packet one-way latency** ~= the configured delay (100 ms).
+2. **burst under load** — 30 packets sent back-to-back at 100 ms drain in
+   bounded time (< 1.2 s) with no loss. The serial-sleep bug would take
+   ~3 s (30 × 100 ms) and shed packets; the delay line drains in ~0.12 s.
+3. **reverse direction** is bounded too — confirms each direction has its own
+   delay line.
+4. **jitter** keeps every sample in a sane window (delay ± jitter + slack).
+5. **no filter** — forwarding stays fast (sanity, regression guard).
+6. **`bridge get_stats`** still reports IN/OUT counters after a burst.
+
+## Running
+
+No privileges needed (high UDP ports only). Build first, then:
+
+```
+make                       # from the repo root
+python3 tests/delay/run_all.py
+```
+
+or a single suite:
+
+```
+cd tests/delay && python3 test_latency.py
+```
+
+Stdlib only — no third-party dependencies. The harness reuses the
+`Ubridge` / `Client` / `Results` helpers from `tests/brctl/common.py`.

--- a/tests/delay/README.md
+++ b/tests/delay/README.md
@@ -27,6 +27,22 @@ UDP NIOs (looped back to receiver sockets under the test's control) and a
 4. **jitter** keeps every sample in a sane window (delay ± jitter + slack).
 5. **no filter** — forwarding stays fast (sanity, regression guard).
 6. **`bridge get_stats`** still reports IN/OUT counters after a burst.
+7. **queue limit** — under overload, delivery is capped at the delay line's
+   depth limit (default 1000 packets, matching the kernel netem limit) and
+   excess packets are tail-dropped, so memory stays bounded while latency
+   stays bounded. Uses `UBRIDGE_DELAY_LIMIT=20` for a deterministic check.
+
+## Tuning
+
+The per-direction queue depth defaults to 1000 packets (same as netem's
+`NETEM_LIMIT_DEFAULT`). Override it without recompiling:
+
+```
+UBRIDGE_DELAY_LIMIT=2000 ubridge -H 127.0.0.1:21000
+```
+
+A packet beyond the limit is tail-dropped (excess load is shed, never buffered
+without bound).
 
 ## Running
 

--- a/tests/delay/helpers.py
+++ b/tests/delay/helpers.py
@@ -1,14 +1,24 @@
 """Shared helpers for the delay test suite.
 
 Loads the brctl common helpers (Ubridge/Client/Results) by file path, like
-tests/link/helpers.py, so the test trees stay independent.
+tests/link/helpers.py, so the test trees stay independent. Also exposes the
+small UDP traffic primitives (bound_udp / send_burst / recv_count / one_way)
+and a bridge builder shared across the delay test files.
+
+ubridge's UDP NIO is a *connected* point-to-point tunnel: a NIO on local port
+L connected to remote port R only accepts datagrams from R (and sends to R).
+So to feed a bridge we send from a socket bound to the NIO's remote port, and
+observe on the peer NIO's remote port. No privileges required (high UDP only).
 """
 import importlib.util
 import os
+import socket
+import struct
+import time
 
-_brctl_common = os.path.join(
-    os.path.dirname(__file__), "..", "brctl", "common.py"
-)
+HOST = "127.0.0.1"
+
+_brctl_common = os.path.join(os.path.dirname(__file__), "..", "brctl", "common.py")
 _spec = importlib.util.spec_from_file_location("brctl_common", _brctl_common)
 _brctl = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_brctl)
@@ -16,3 +26,78 @@ _spec.loader.exec_module(_brctl)
 Ubridge = _brctl.Ubridge
 Client = _brctl.Client
 Results = _brctl.Results
+
+
+def ubridge_binary():
+    """Prefer the just-built repo binary (delay tests need no privileges, and
+    the installed /usr/local/bin/ubridge may be a stale pre-fix copy). Honours
+    UBRIDGE_BINARY; falls back to the shared resolver."""
+    repo = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "ubridge"))
+    env = os.environ.get("UBRIDGE_BINARY")
+    if env and os.path.exists(env):
+        return env
+    if os.path.exists(repo):
+        return repo
+    return _brctl.ubridge_binary()
+
+
+def bound_udp(port):
+    """UDP socket bound to `port` — fixed-source injector or receiver."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind((HOST, port))
+    s.settimeout(5.0)
+    return s
+
+
+def send_burst(tx, dst, n, payload=b"x"):
+    """Send n datagrams back-to-back; return the monotonic time of the first."""
+    t0 = time.monotonic()
+    for i in range(n):
+        tx.sendto(struct.pack("!I", i) + payload, dst)
+    return t0
+
+
+def recv_count(rx, n, timeout=5.0, maxpkt=2048):
+    """Receive up to n datagrams; return (count, time_of_last_arrival)."""
+    deadline = time.monotonic() + timeout
+    count = 0
+    t_last = None
+    while count < n:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        rx.settimeout(remaining)
+        try:
+            rx.recv(maxpkt)
+        except socket.timeout:
+            break
+        count += 1
+        t_last = time.monotonic()
+    return count, t_last
+
+
+def one_way(tx, dst, rx, payload=b"ping"):
+    """Send one datagram from bound tx, return one-way latency in s (or None)."""
+    t0 = time.monotonic()
+    tx.sendto(payload, dst)
+    try:
+        rx.recv(2048)
+    except socket.timeout:
+        return None
+    return time.monotonic() - t0
+
+
+def build_bridge(c, name, base, filters=None):
+    """Create a started bridge with two connected UDP NIOs and zero or more
+    packet filters (each "filters" entry is a full filter spec without the
+    bridge/name, e.g. "delay 100" or "packet_loss 50"). Returns (L1,R1,L2,R2)."""
+    l1, r1, l2, r2 = base, base + 1, base + 2, base + 3
+    assert c.code("bridge create %s" % name) == "100", "create %s" % name
+    assert c.code("bridge add_nio_udp %s %d %s %d" % (name, l1, HOST, r1)) == "100"
+    assert c.code("bridge add_nio_udp %s %d %s %d" % (name, l2, HOST, r2)) == "100"
+    for i, spec in enumerate(filters or []):
+        assert c.code("bridge add_packet_filter %s f%d %s" % (name, i, spec)) == "100", spec
+    assert c.code("bridge start %s" % name) == "100", "start %s" % name
+    time.sleep(0.2)  # let the listener threads come up
+    return l1, r1, l2, r2

--- a/tests/delay/helpers.py
+++ b/tests/delay/helpers.py
@@ -1,0 +1,18 @@
+"""Shared helpers for the delay test suite.
+
+Loads the brctl common helpers (Ubridge/Client/Results) by file path, like
+tests/link/helpers.py, so the test trees stay independent.
+"""
+import importlib.util
+import os
+
+_brctl_common = os.path.join(
+    os.path.dirname(__file__), "..", "brctl", "common.py"
+)
+_spec = importlib.util.spec_from_file_location("brctl_common", _brctl_common)
+_brctl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_brctl)
+
+Ubridge = _brctl.Ubridge
+Client = _brctl.Client
+Results = _brctl.Results

--- a/tests/delay/run_all.py
+++ b/tests/delay/run_all.py
@@ -1,0 +1,28 @@
+"""Run the whole delay test suite in sequence, exit non-zero if any fail."""
+import importlib
+import sys
+
+SUITES = [
+    "test_latency",
+]
+
+
+def main():
+    overall = 0
+    for name in SUITES:
+        print("\n" + "=" * 60)
+        print(name)
+        print("=" * 60)
+        mod = importlib.import_module(name)
+        rc = mod.main()
+        if rc != 0:
+            overall = rc
+    print("\n" + "=" * 60)
+    print("ALL SUITES: " + ("PASS" if overall == 0 else "FAIL"))
+    print("=" * 60)
+    return overall
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, __file__[: -len("run_all.py")])
+    raise SystemExit(main())

--- a/tests/delay/run_all.py
+++ b/tests/delay/run_all.py
@@ -6,6 +6,7 @@ SUITES = [
     "test_latency",
     "test_perf",
     "test_boundary",
+    "test_iol",
 ]
 
 

--- a/tests/delay/run_all.py
+++ b/tests/delay/run_all.py
@@ -4,6 +4,8 @@ import sys
 
 SUITES = [
     "test_latency",
+    "test_perf",
+    "test_boundary",
 ]
 
 

--- a/tests/delay/test_boundary.py
+++ b/tests/delay/test_boundary.py
@@ -1,0 +1,137 @@
+"""Boundary tests for the delay filter: minimum/edge configs, packet sizes,
+and teardown while packets are still queued.
+
+No privileges required (UDP only). Stdlib only.
+"""
+import os
+import socket
+import time
+
+from helpers import (Ubridge, Results, HOST, ubridge_binary, bound_udp,
+                     send_burst, recv_count, one_way, build_bridge)
+
+PORT = 14400
+
+
+def main():
+    r = Results()
+    with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        try:
+            # ---- 1. minimum latency (1ms; delay_setup rejects <= 0) ----
+            l1, r1, l2, r2 = build_bridge(c, "b1", 14410, ["delay 1"])
+            tx = bound_udp(r1)
+            rx = bound_udp(r2)
+            ow = one_way(tx, (HOST, l1), rx)
+            r.check("boundary: min latency 1ms works (< 50ms)",
+                    ow is not None and ow < 0.050, "%.0fms" % ((ow or -1) * 1000))
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop b1") == "100"
+            assert c.code("bridge delete b1") == "100"
+
+            # ---- 2. jitter > latency (negatives clamp to 0, no crash) ----
+            l1, r1, l2, r2 = build_bridge(c, "b2", 14420, ["delay 50 100"])
+            tx = bound_udp(r1)
+            rx = bound_udp(r2)
+            send_burst(tx, (HOST, l1), 2)
+            recv_count(rx, 2, timeout=2.0)
+            samples = [s * 1000 for s in (one_way(tx, (HOST, l1), rx) for _ in range(12)) if s]
+            # no crash / all clamped into range; and jitter does throw positive
+            # samples too (not every packet clamps to 0).
+            r.check("boundary: jitter>latency no crash, all in [0,600]ms",
+                    len(samples) >= 8 and all(0 <= s < 600 for s in samples),
+                    "n=%d max=%.0fms" % (len(samples), max(samples) if samples else -1))
+            r.check("boundary: jitter>latency shows positive delays",
+                    max(samples) > 10 if samples else False,
+                    "max=%.0fms" % (max(samples) if samples else -1))
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop b2") == "100"
+            assert c.code("bridge delete b2") == "100"
+
+            # ---- 3. packet-size boundaries through delay (1 byte and ~60 KB) ----
+            l1, r1, l2, r2 = build_bridge(c, "b3", 14430, ["delay 30"])
+            tx = bound_udp(r1)
+            rx = bound_udp(r2)
+            rx.settimeout(3.0)
+            tx.sendto(b"z", (HOST, l1))
+            got_tiny = False
+            try:
+                got_tiny = (rx.recv(70000) == b"z")
+            except socket.timeout:
+                pass
+            big = b"Q" * 60000
+            tx.sendto(big, (HOST, l1))
+            got_big = False
+            try:
+                got_big = (len(rx.recv(70000)) == 60000)
+            except socket.timeout:
+                pass
+            r.check("boundary: 1-byte packet through delay", got_tiny)
+            r.check("boundary: 60KB packet through delay", got_big)
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop b3") == "100"
+            assert c.code("bridge delete b3") == "100"
+
+            # ---- 4. stop the bridge while packets are still queued (no hang) ----
+            l1, r1, l2, r2 = build_bridge(c, "b4", 14440, ["delay 2000"])
+            tx = bound_udp(r1)
+            rx = bound_udp(r2)
+            send_burst(tx, (HOST, l1), 20)   # queued, not due for 2s
+            time.sleep(0.1)
+            t0 = time.monotonic()
+            assert c.code("bridge stop b4") == "100"   # joins release thread, frees queue
+            assert c.code("bridge delete b4") == "100"
+            dt = (time.monotonic() - t0) * 1000
+            r.check("boundary: stop with queued pkts < 1s (no hang)",
+                    dt < 1000.0, "stop+delete=%.0fms" % dt)
+            tx.close()
+            rx.close()
+            # ubridge is still responsive after cancel-with-queued-packets
+            l1, r1, l2, r2 = build_bridge(c, "b4b", 14450, ["delay 10"])
+            tx = bound_udp(r1)
+            rx = bound_udp(r2)
+            ow = one_way(tx, (HOST, l1), rx)
+            r.check("boundary: responsive after cancel-with-queue",
+                    ow is not None and ow < 0.100, "%.0fms" % ((ow or -1) * 1000))
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop b4b") == "100"
+            assert c.code("bridge delete b4b") == "100"
+        finally:
+            c.close()
+
+    # ---- 5. queue-limit boundary (separate session, UBRIDGE_DELAY_LIMIT=10) ----
+    os.environ["UBRIDGE_DELAY_LIMIT"] = "10"
+    try:
+        with Ubridge(port=14460, binary=ubridge_binary()) as ub:
+            c = ub.connect()
+            try:
+                l1, r1, l2, r2 = build_bridge(c, "b5", 14470, ["delay 100"])
+                tx = bound_udp(r1)
+                rx = bound_udp(r2)
+                # exactly the limit: all delivered
+                send_burst(tx, (HOST, l1), 10)
+                n_at, _ = recv_count(rx, 10, timeout=2.0)
+                # one over the limit: still 10 (1 tail-dropped)
+                send_burst(tx, (HOST, l1), 11)
+                n_over, _ = recv_count(rx, 11, timeout=0.8)
+                r.check("boundary: limit==delivered (10/10)", n_at == 10, "%d/10" % n_at)
+                r.check("boundary: limit caps delivery at 10 (11 sent)",
+                        n_over == 10, "%d/11" % n_over)
+                tx.close()
+                rx.close()
+                assert c.code("bridge stop b5") == "100"
+                assert c.code("bridge delete b5") == "100"
+            finally:
+                c.close()
+    finally:
+        os.environ.pop("UBRIDGE_DELAY_LIMIT", None)
+
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/delay/test_iol.py
+++ b/tests/delay/test_iol.py
@@ -1,0 +1,134 @@
+"""IOL bridge delay regression.
+
+A naive delay-line fix only wired bridge_nios (the UDP bridge); IOL bridges
+run their own filter->handler loops and would silently lose delay. This drives
+the IOL bridge end-to-end — acting as a fake IOL instance over the netio
+unix-domain socket — and checks delay applies in BOTH directions, plus that
+teardown with delay active doesn't hang.
+
+IOL bridge add_nio_udp: <bridge> <iol_id> <bay> <unit> <lport> <rhost> <rport>
+The bridge binds /tmp/netio{uid}/{app_id}; an IOL instance lives at
+/tmp/netio{uid}/{iol_id}. destination_nio is a connected UDP NIO (lport<->rport).
+"""
+import os
+import socket
+import time
+
+from helpers import Ubridge, Results, HOST, ubridge_binary
+
+UID = os.getuid()
+NETIO_DIR = "/tmp/netio%u" % UID
+APP_ID = 9001      # the IOL bridge
+IOL_ID = 9002      # the fake IOL instance
+BRIDGE_SOCK = "%s/%d" % (NETIO_DIR, APP_ID)
+IOL_SOCK = "%s/%d" % (NETIO_DIR, IOL_ID)
+
+LPORT, RPORT = 15010, 15011        # destination_nio: local LPORT, remote RPORT
+PK = 0                             # port_key (bay=0, unit=0)
+
+
+def iol_frame(dst_id, src_id, port_key, payload):
+    f = bytearray(8)
+    f[0], f[1] = (dst_id >> 8) & 0xff, dst_id & 0xff    # DST_IDS
+    f[2], f[3] = (src_id >> 8) & 0xff, src_id & 0xff    # SRC_IDS
+    f[4] = port_key & 0xff                              # DST_PORT
+    f[5] = port_key & 0xff                              # SRC_PORT
+    f[6] = 1                                            # MSG_TYPE = DATA
+    f[7] = 0                                            # CHANNEL
+    return bytes(f) + payload
+
+
+def main():
+    r = Results()
+    # GNS3 creates /tmp/netio{uid}/; ubridge just binds into it, so make it.
+    try:
+        os.makedirs(NETIO_DIR, 0o777)
+    except FileExistsError:
+        pass
+
+    with Ubridge(port=14900, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        iol = None
+        try:
+            # fake IOL instance unix socket
+            iol = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+            try:
+                os.unlink(IOL_SOCK)
+            except OSError:
+                pass
+            iol.bind(IOL_SOCK)
+            iol.settimeout(5)
+
+            assert c.code("iol_bridge create iol1 %d" % APP_ID) == "100"
+            assert c.code("iol_bridge add_nio_udp iol1 %d 0 0 %d %s %d" % (IOL_ID, LPORT, HOST, RPORT)) == "100"
+            assert c.code("iol_bridge add_packet_filter iol1 0 0 d1 delay 100") == "100"
+            assert c.code("iol_bridge start iol1") == "100"
+            time.sleep(0.3)
+
+            # ---- IOL -> NIO direction (iol_bridge_listener) ----
+            # IOL instance sends a framed packet to the bridge; bridge strips the
+            # IOL header and forwards the payload out the destination NIO (UDP).
+            rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            rx.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            rx.bind((HOST, RPORT))
+            rx.settimeout(5)
+            iol.sendto(iol_frame(APP_ID, IOL_ID, PK, b"warmup"), BRIDGE_SOCK)  # prime
+            try:
+                rx.recv(2048)
+            except socket.timeout:
+                pass
+            t0 = time.monotonic()
+            iol.sendto(iol_frame(APP_ID, IOL_ID, PK, b"ping"), BRIDGE_SOCK)
+            try:
+                rx.recv(2048)
+                ow = (time.monotonic() - t0) * 1000
+            except socket.timeout:
+                ow = None
+            r.check("IOL: IOL->NIO delay ~100ms",
+                    ow is not None and 50 < ow < 300, "%.0fms" % (ow or -1))
+            rx.close()
+
+            # ---- NIO -> IOL direction (iol_nio_listener) ----
+            # Inject into the destination NIO (source = RPORT so the connected
+            # NIO accepts); bridge prepends the IOL header and sends to the
+            # IOL instance socket.
+            tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            tx.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            tx.bind((HOST, RPORT))
+            tx.sendto(b"warmup", (HOST, LPORT))  # prime
+            try:
+                iol.recv(4096)
+            except socket.timeout:
+                pass
+            t0 = time.monotonic()
+            tx.sendto(b"pong", (HOST, LPORT))
+            try:
+                iol.recv(4096)
+                ow2 = (time.monotonic() - t0) * 1000
+            except socket.timeout:
+                ow2 = None
+            r.check("IOL: NIO->IOL delay ~100ms",
+                    ow2 is not None and 50 < ow2 < 300, "%.0fms" % (ow2 or -1))
+            tx.close()
+
+            # ---- teardown with delay active doesn't hang ----
+            t0 = time.monotonic()
+            assert c.code("iol_bridge stop iol1") == "100"
+            assert c.code("iol_bridge delete iol1") == "100"
+            r.check("IOL: stop+delete with delay active < 3s",
+                    (time.monotonic() - t0) < 3.0, "%.0fms" % ((time.monotonic() - t0) * 1000))
+        finally:
+            if iol is not None:
+                iol.close()
+            c.close()
+            for p in (IOL_SOCK, BRIDGE_SOCK):
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
+
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/delay/test_latency.py
+++ b/tests/delay/test_latency.py
@@ -154,16 +154,26 @@ def main():
             assert c.code("bridge stop d1") == "100"
             assert c.code("bridge delete d1") == "100"
 
-            # ---- 4. jitter keeps latency in a sane window ----
+            # ---- 4. jitter is Gaussian, centred on the delay ----
+            # With jitter the per-packet delay is N(latency, jitter^2), so check
+            # the sample mean and spread rather than each sample being in a fixed
+            # band (a normal distribution legitimately throws low-tail samples).
             l1, r1, l2, r2 = _build_bridge(c, "d2", delay_ms=50, jitter_ms=30, base=13070)
             tx = _udp_bound(r1)
             rx = _udp_bound(r2)
-            bad = 0
-            for _ in range(8):
+            samples = []
+            for _ in range(20):
                 ow = _one_way(tx, (HOST, l1), rx)
-                if ow is None or not (0.010 < ow < 0.300):  # 50ms +/- 30 + slack
-                    bad += 1
-            r.check("jitter: all samples in [10,300]ms", bad == 0, "%d/8 out of band" % bad)
+                if ow is not None:
+                    samples.append(ow * 1000.0)   # ms
+            mean = sum(samples) / len(samples) if samples else -1.0
+            spread = (max(samples) - min(samples)) if samples else -1.0
+            r.check("jitter: mean ~50ms (Gaussian)", len(samples) >= 15 and 30 < mean < 80,
+                    "mean=%.0fms n=%d" % (mean, len(samples)))
+            r.check("jitter: spread present (>15ms)", spread > 15,
+                    "spread=%.0fms" % spread)
+            r.check("jitter: samples bounded (<200ms)",
+                    all(s < 200 for s in samples), "max=%.0fms" % (max(samples) if samples else -1))
             tx.close()
             rx.close()
             assert c.code("bridge stop d2") == "100"

--- a/tests/delay/test_latency.py
+++ b/tests/delay/test_latency.py
@@ -26,90 +26,21 @@ import socket
 import struct
 import time
 
-from helpers import Ubridge, Results
-
-HOST = "127.0.0.1"
-
-
-def _binary():
-    """Prefer the just-built repo binary — the delay filter needs no
-    privileges (UDP only), and the installed /usr/local/bin/ubridge may be a
-    stale pre-fix copy. Falls back to the shared resolver otherwise."""
-    repo = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "ubridge"))
-    env = os.environ.get("UBRIDGE_BINARY")
-    if env and os.path.exists(env):
-        return env
-    if os.path.exists(repo):
-        return repo
-    from helpers import _brctl
-    return _brctl.ubridge_binary()
-
-
-def _udp_bound(port):
-    """A UDP socket bound to `port` — used as a fixed-source injector (so the
-    connected NIO accepts our datagrams) or as a receiver."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.bind((HOST, port))
-    s.settimeout(5.0)
-    return s
+from helpers import (Ubridge, Results, HOST, ubridge_binary as _binary,
+                     bound_udp as _udp_bound, send_burst as _send_burst,
+                     recv_count as _recv_count, one_way as _one_way)
 
 
 def _build_bridge(c, name, delay_ms=None, jitter_ms=None, base=13060):
     """Create a started bridge with two connected UDP NIOs and an optional
     delay filter. Returns (L1, R1, L2, R2)."""
-    l1, r1, l2, r2 = base, base + 1, base + 2, base + 3
-
-    assert c.code("bridge create %s" % name) == "100", "create bridge"
-    assert c.code("bridge add_nio_udp %s %d %s %d" % (name, l1, HOST, r1)) == "100"
-    assert c.code("bridge add_nio_udp %s %d %s %d" % (name, l2, HOST, r2)) == "100"
     if delay_ms is not None:
-        if jitter_ms is not None:
-            cmd = "bridge add_packet_filter %s d1 delay %d %d" % (name, delay_ms, jitter_ms)
-        else:
-            cmd = "bridge add_packet_filter %s d1 delay %d" % (name, delay_ms)
-        assert c.code(cmd) == "100", "add delay filter"
-    assert c.code("bridge start %s" % name) == "100", "start bridge"
-    time.sleep(0.2)  # let the listener threads come up
-    return l1, r1, l2, r2
-
-
-def _send_burst(tx, dst, n, payload=b"x"):
-    """Send n datagrams back-to-back; return the monotonic time of the first."""
-    t0 = time.monotonic()
-    for i in range(n):
-        tx.sendto(struct.pack("!I", i) + payload, dst)
-    return t0
-
-
-def _recv_count(rx, n, timeout=5.0):
-    """Receive up to n datagrams; return (count, time_of_last_arrival)."""
-    deadline = time.monotonic() + timeout
-    count = 0
-    t_last = None
-    while count < n:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            break
-        rx.settimeout(remaining)
-        try:
-            rx.recv(2048)
-        except socket.timeout:
-            break
-        count += 1
-        t_last = time.monotonic()
-    return count, t_last
-
-
-def _one_way(tx, dst, rx, payload=b"ping"):
-    """Send one datagram from bound tx, return one-way latency (or None on loss)."""
-    t0 = time.monotonic()
-    tx.sendto(payload, dst)
-    try:
-        rx.recv(2048)
-    except socket.timeout:
-        return None
-    return time.monotonic() - t0
+        spec = "delay %d" % delay_ms if jitter_ms is None else "delay %d %d" % (delay_ms, jitter_ms)
+        filters = [spec]
+    else:
+        filters = None
+    from helpers import build_bridge
+    return build_bridge(c, name, base, filters)
 
 
 def main():

--- a/tests/delay/test_latency.py
+++ b/tests/delay/test_latency.py
@@ -196,6 +196,56 @@ def main():
             rx.close()
             assert c.code("bridge stop d4") == "100"
             assert c.code("bridge delete d4") == "100"
+
+            # ---- 7. runtime filter management (GNS3 starts, then applies) ----
+            # gns3-server does `bridge start` THEN `_ubridge_apply_filters`, and
+            # re-applies on link update — so a delay filter added/changed/removed
+            # on a RUNNING bridge must take effect immediately (the old one-shot
+            # read at start left it silently inert; the regression behind
+            # "configured 100ms but no effect").
+            l1, r1, l2, r2 = (13110, 13111, 13112, 13113)
+            assert c.code("bridge create d6") == "100"
+            assert c.code("bridge add_nio_udp d6 %d %s %d" % (l1, HOST, r1)) == "100"
+            assert c.code("bridge add_nio_udp d6 %d %s %d" % (l2, HOST, r2)) == "100"
+            assert c.code("bridge start d6") == "100"
+            time.sleep(0.2)
+            tx = _udp_bound(r1)
+            rx = _udp_bound(r2)
+            ow = _one_way(tx, (HOST, l1), rx)
+            r.check("runtime: no filter -> ~0ms", ow is not None and ow < 0.050,
+                    "%.0f ms" % (ow * 1000) if ow else "lost")
+            r.check("runtime: add delay 80 after start -> 100",
+                    c.code("bridge add_packet_filter d6 d1 delay 80") == "100")
+            time.sleep(0.2)
+            # prime the lazy delay-line creation, then measure (avoids measuring
+            # the very first packet that races the filter-becoming-visible)
+            _send_burst(tx, (HOST, l1), 2)
+            _recv_count(rx, 2, timeout=1.0)
+            ow = _one_way(tx, (HOST, l1), rx)
+            r.check("runtime: delay 80 takes effect",
+                    ow is not None and 0.050 < ow < 0.250,
+                    "%.0f ms" % (ow * 1000) if ow else "lost")
+            # change params: reset + re-add at 150
+            assert c.code("bridge reset_packet_filters d6") == "100"
+            assert c.code("bridge add_packet_filter d6 d1 delay 150") == "100"
+            time.sleep(0.2)
+            _send_burst(tx, (HOST, l1), 2)
+            _recv_count(rx, 2, timeout=1.0)
+            ow = _one_way(tx, (HOST, l1), rx)
+            r.check("runtime: change to delay 150 takes effect",
+                    ow is not None and 0.110 < ow < 0.350,
+                    "%.0f ms" % (ow * 1000) if ow else "lost")
+            # remove
+            assert c.code("bridge reset_packet_filters d6") == "100"
+            time.sleep(0.2)
+            ow = _one_way(tx, (HOST, l1), rx)
+            r.check("runtime: remove filter -> back to ~0ms",
+                    ow is not None and ow < 0.050,
+                    "%.0f ms" % (ow * 1000) if ow else "lost")
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop d6") == "100"
+            assert c.code("bridge delete d6") == "100"
         finally:
             c.close()
 

--- a/tests/delay/test_latency.py
+++ b/tests/delay/test_latency.py
@@ -1,0 +1,207 @@
+"""Regression for the delay packet filter (GNS3/ubridge#114).
+
+The old delay filter slept inline in the per-direction bridge thread
+(nanosleep), so each direction serviced at most ~1000/latency pps and the link
+collapsed under any heavier load (latency ballooned, then packet loss). The
+fix routes delayed sends through a real delay line with a dedicated release
+thread, so the recv loop never blocks and per-packet latency stays bounded.
+
+This drives ubridge's hypervisor protocol directly. ubridge's UDP NIO is a
+*connected* point-to-point tunnel: a NIO on local port L connected to remote
+port R only accepts datagrams from R (and sends to R). So to feed a bridge we
+send from a socket bound to the NIO's remote port, and we observe on the peer
+NIO's remote port. No privileges required (high UDP ports only). Stdlib only.
+
+Topology (all on 127.0.0.1), one bridge "B" with two NIOs:
+
+  source_nio: L1 <--> R1      dest_nio: L2 <--> R2
+
+  forward (inject at source, observe at dest):
+    bound-R1 socket --sendto--> L1  ==> bridge[delay] ==> dest_nio --sendto--> R2 (rx)
+  reverse (inject at dest, observe at source):
+    bound-R2 socket --sendto--> L2  ==> bridge[delay] ==> source_nio --sendto--> R1 (rx)
+"""
+import os
+import socket
+import struct
+import time
+
+from helpers import Ubridge, Results
+
+HOST = "127.0.0.1"
+
+
+def _binary():
+    """Prefer the just-built repo binary — the delay filter needs no
+    privileges (UDP only), and the installed /usr/local/bin/ubridge may be a
+    stale pre-fix copy. Falls back to the shared resolver otherwise."""
+    repo = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "ubridge"))
+    env = os.environ.get("UBRIDGE_BINARY")
+    if env and os.path.exists(env):
+        return env
+    if os.path.exists(repo):
+        return repo
+    from helpers import _brctl
+    return _brctl.ubridge_binary()
+
+
+def _udp_bound(port):
+    """A UDP socket bound to `port` — used as a fixed-source injector (so the
+    connected NIO accepts our datagrams) or as a receiver."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind((HOST, port))
+    s.settimeout(5.0)
+    return s
+
+
+def _build_bridge(c, name, delay_ms=None, jitter_ms=None, base=13060):
+    """Create a started bridge with two connected UDP NIOs and an optional
+    delay filter. Returns (L1, R1, L2, R2)."""
+    l1, r1, l2, r2 = base, base + 1, base + 2, base + 3
+
+    assert c.code("bridge create %s" % name) == "100", "create bridge"
+    assert c.code("bridge add_nio_udp %s %d %s %d" % (name, l1, HOST, r1)) == "100"
+    assert c.code("bridge add_nio_udp %s %d %s %d" % (name, l2, HOST, r2)) == "100"
+    if delay_ms is not None:
+        if jitter_ms is not None:
+            cmd = "bridge add_packet_filter %s d1 delay %d %d" % (name, delay_ms, jitter_ms)
+        else:
+            cmd = "bridge add_packet_filter %s d1 delay %d" % (name, delay_ms)
+        assert c.code(cmd) == "100", "add delay filter"
+    assert c.code("bridge start %s" % name) == "100", "start bridge"
+    time.sleep(0.2)  # let the listener threads come up
+    return l1, r1, l2, r2
+
+
+def _send_burst(tx, dst, n, payload=b"x"):
+    """Send n datagrams back-to-back; return the monotonic time of the first."""
+    t0 = time.monotonic()
+    for i in range(n):
+        tx.sendto(struct.pack("!I", i) + payload, dst)
+    return t0
+
+
+def _recv_count(rx, n, timeout=5.0):
+    """Receive up to n datagrams; return (count, time_of_last_arrival)."""
+    deadline = time.monotonic() + timeout
+    count = 0
+    t_last = None
+    while count < n:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        rx.settimeout(remaining)
+        try:
+            rx.recv(2048)
+        except socket.timeout:
+            break
+        count += 1
+        t_last = time.monotonic()
+    return count, t_last
+
+
+def _one_way(tx, dst, rx, payload=b"ping"):
+    """Send one datagram from bound tx, return one-way latency (or None on loss)."""
+    t0 = time.monotonic()
+    tx.sendto(payload, dst)
+    try:
+        rx.recv(2048)
+    except socket.timeout:
+        return None
+    return time.monotonic() - t0
+
+
+def main():
+    r = Results()
+
+    with Ubridge(port=13099, binary=_binary()) as ub:
+        c = ub.connect()
+        try:
+            # ---- 1. single-packet one-way latency ~= configured delay ----
+            l1, r1, l2, r2 = _build_bridge(c, "d1", delay_ms=100)
+            tx = _udp_bound(r1)          # inject forward: source addr = R1
+            rx = _udp_bound(r2)          # observe forward out at R2
+            ow = _one_way(tx, (HOST, l1), rx)
+            r.check("fwd one-packet ~delay (100ms)",
+                    ow is not None and 0.060 < ow < 0.450,
+                    "%.0f ms" % (ow * 1000) if ow else "lost")
+
+            # ---- 2. burst drains in bounded time (the #114 regression) ----
+            # 30 pkts at 100ms: serial-sleep bug ~ 3.0s; delay-line fix ~ 0.12s.
+            n = 30
+            t0 = _send_burst(tx, (HOST, l1), n)
+            count, t_last = _recv_count(rx, n, timeout=4.0)
+            drain = (t_last - t0) if t_last else float("inf")
+            r.check("burst: no loss under load", count == n, "%d/%d" % (count, n))
+            r.check("burst: latency stays bounded (drain < 1.2s)",
+                    drain < 1.2, "drain=%.0fms" % (drain * 1000))
+            tx.close()
+            rx.close()
+
+            # ---- 3. reverse direction is bounded too (each dir has its line) ----
+            tx = _udp_bound(r2)          # inject reverse: source addr = R2
+            rx = _udp_bound(r1)          # observe reverse out at R1
+            t0 = _send_burst(tx, (HOST, l2), n)
+            count, t_last = _recv_count(rx, n, timeout=4.0)
+            drain_r = (t_last - t0) if t_last else float("inf")
+            r.check("reverse burst: no loss", count == n, "%d/%d" % (count, n))
+            r.check("reverse burst: bounded (drain < 1.2s)",
+                    drain_r < 1.2, "drain=%.0fms" % (drain_r * 1000))
+            tx.close()
+            rx.close()
+
+            assert c.code("bridge stop d1") == "100"
+            assert c.code("bridge delete d1") == "100"
+
+            # ---- 4. jitter keeps latency in a sane window ----
+            l1, r1, l2, r2 = _build_bridge(c, "d2", delay_ms=50, jitter_ms=30, base=13070)
+            tx = _udp_bound(r1)
+            rx = _udp_bound(r2)
+            bad = 0
+            for _ in range(8):
+                ow = _one_way(tx, (HOST, l1), rx)
+                if ow is None or not (0.010 < ow < 0.300):  # 50ms +/- 30 + slack
+                    bad += 1
+            r.check("jitter: all samples in [10,300]ms", bad == 0, "%d/8 out of band" % bad)
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop d2") == "100"
+            assert c.code("bridge delete d2") == "100"
+
+            # ---- 5. no delay filter: forwarding still fast (sanity) ----
+            l1, r1, l2, r2 = _build_bridge(c, "d3", base=13080)
+            tx = _udp_bound(r1)
+            rx = _udp_bound(r2)
+            ow = _one_way(tx, (HOST, l1), rx)
+            r.check("no-filter one-way < 50ms",
+                    ow is not None and ow < 0.050,
+                    "%.0f ms" % (ow * 1000) if ow else "lost")
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop d3") == "100"
+            assert c.code("bridge delete d3") == "100"
+
+            # ---- 6. stats reflect the traffic ----
+            l1, r1, l2, r2 = _build_bridge(c, "d4", delay_ms=20, base=13090)
+            tx = _udp_bound(r1)
+            rx = _udp_bound(r2)
+            _send_burst(tx, (HOST, l1), 5)
+            _recv_count(rx, 5, timeout=2.0)
+            stats = c.send("bridge get_stats d4")
+            r.check("get_stats shows traffic after burst",
+                    "IN: 5 packets" in stats or "IN:      5" in stats,
+                    stats.replace("\r", " | ").strip()[:90])
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop d4") == "100"
+            assert c.code("bridge delete d4") == "100"
+        finally:
+            c.close()
+
+    ok = r.summary()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/delay/test_latency.py
+++ b/tests/delay/test_latency.py
@@ -199,6 +199,35 @@ def main():
         finally:
             c.close()
 
+    # ---- 7. queue limit: overload is tail-dropped, delivery is bounded ----
+    # A separate session with a tiny limit (UBRIDGE_DELAY_LIMIT=20) so the
+    # user-space drop path is hit deterministically. Every delivered packet
+    # transits the queue, so delivery is capped at the limit; without the cap
+    # an offered burst is buffered without bound (the memory side of #114).
+    os.environ["UBRIDGE_DELAY_LIMIT"] = "20"
+    try:
+        with Ubridge(port=13098, binary=_binary()) as ub:
+            c = ub.connect()
+            try:
+                l1, r1, l2, r2 = _build_bridge(c, "d5", delay_ms=100, base=13100)
+                tx = _udp_bound(r1)
+                rx = _udp_bound(r2)
+                t0 = _send_burst(tx, (HOST, l1), 200)        # 200 >> limit(20)
+                count, t_last = _recv_count(rx, 200, timeout=3.0)
+                drain = (t_last - t0) if t_last else float("inf")
+                r.check("limit: delivery capped at <=20",
+                        0 < count <= 20, "%d/200 delivered" % count)
+                r.check("limit: latency still bounded (drain < 1.5s)",
+                        drain < 1.5, "drain=%.0fms" % (drain * 1000))
+                tx.close()
+                rx.close()
+                assert c.code("bridge stop d5") == "100"
+                assert c.code("bridge delete d5") == "100"
+            finally:
+                c.close()
+    finally:
+        os.environ.pop("UBRIDGE_DELAY_LIMIT", None)
+
     ok = r.summary()
     return 0 if ok else 1
 

--- a/tests/delay/test_latency.py
+++ b/tests/delay/test_latency.py
@@ -246,6 +246,31 @@ def main():
             rx.close()
             assert c.code("bridge stop d6") == "100"
             assert c.code("bridge delete d6") == "100"
+
+            # ---- 8. composition: delay + packet_loss (filters combine) ----
+            # Only delay was special-cased (moved to the delay line); loss and
+            # corrupt stay inline. Dropped packets never enter the delay line,
+            # survivors are delayed -- so ~50% delivered, each by ~delay.
+            l1, r1, l2, r2 = (13120, 13121, 13122, 13123)
+            assert c.code("bridge create d7") == "100"
+            assert c.code("bridge add_nio_udp d7 %d %s %d" % (l1, HOST, r1)) == "100"
+            assert c.code("bridge add_nio_udp d7 %d %s %d" % (l2, HOST, r2)) == "100"
+            assert c.code("bridge add_packet_filter d7 f0 delay 60") == "100"
+            assert c.code("bridge add_packet_filter d7 f1 packet_loss 50") == "100"
+            assert c.code("bridge start d7") == "100"
+            time.sleep(0.2)
+            tx = _udp_bound(r1)
+            rx = _udp_bound(r2)
+            t0 = _send_burst(tx, (HOST, l1), 200)
+            count, t_last = _recv_count(rx, 200, timeout=3.0)
+            drain = (t_last - t0) if t_last else float("inf")
+            r.check("combo delay+loss: ~50% delivered", 60 <= count <= 140, "%d/200" % count)
+            r.check("combo delay+loss: survivors delayed ~60ms",
+                    0.030 < drain < 0.200, "drain=%.0fms" % (drain * 1000))
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop d7") == "100"
+            assert c.code("bridge delete d7") == "100"
         finally:
             c.close()
 

--- a/tests/delay/test_perf.py
+++ b/tests/delay/test_perf.py
@@ -1,0 +1,79 @@
+"""Performance regression for the delay filter (GNS3/ubridge#114).
+
+The #114 failure mode was structural collapse under load: the old inline
+nanosleep serialized each direction to ~1000/latency pps, so a burst took
+~N*latency to drain and latency ballooned without bound. These check the delay
+line sustains throughput and keeps latency bounded at scale, that delay is
+accurate across magnitudes, and that the no-filter fast path isn't regressed.
+
+No privileges required (UDP only). Stdlib only.
+"""
+from helpers import (Ubridge, Results, HOST, ubridge_binary, bound_udp,
+                     send_burst, recv_count, one_way, build_bridge)
+
+PORT = 14200
+
+
+def main():
+    r = Results()
+    with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        try:
+            # ---- 1. large burst drains in bounded time (anti-#114 at scale) ----
+            # 400 pkts @50ms: the serial-sleep bug drained in ~400*50ms = 20s;
+            # the delay line drains in ~50ms (recv never blocks).
+            l1, r1, l2, r2 = build_bridge(c, "p1", 14210, ["delay 50"])
+            tx = bound_udp(r1)
+            rx = bound_udp(r2)
+            t0 = send_burst(tx, (HOST, l1), 400)
+            count, t_last = recv_count(rx, 400, timeout=5.0)
+            drain = (t_last - t0) if t_last else 999.0
+            r.check("perf: 400-pkt burst @50ms drains < 2s",
+                    drain < 2.0, "drain=%.0fms" % (drain * 1000))
+            r.check("perf: burst delivered with little loss", count >= 380, "%d/400" % count)
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop p1") == "100"
+            assert c.code("bridge delete p1") == "100"
+
+            # ---- 2. delay accuracy across magnitudes ----
+            for k, cfg in enumerate((10, 100, 500)):
+                name = "p2_%d" % cfg
+                l1, r1, l2, r2 = build_bridge(c, name, 14240 + k * 10, ["delay %d" % cfg])
+                tx = bound_udp(r1)
+                rx = bound_udp(r2)
+                send_burst(tx, (HOST, l1), 2)
+                recv_count(rx, 2, timeout=2.0)  # prime the lazy delay line
+                ows = sorted(o * 1000 for o in (one_way(tx, (HOST, l1), rx) for _ in range(3)) if o)
+                med = ows[len(ows) // 2] if ows else -1.0
+                r.check("perf: delay %dms ~= measured" % cfg,
+                        0.6 * cfg < med < 1.6 * cfg, "med=%.0fms" % med)
+                tx.close()
+                rx.close()
+                assert c.code("bridge stop %s" % name) == "100"
+                assert c.code("bridge delete %s" % name) == "100"
+
+            # ---- 3. no-delay forwarding throughput baseline (regression guard) ----
+            # Sized to fit the kernel UDP receive buffer -- an instant 1000-pkt
+            # burst overflows it regardless of ubridge (the delay path actually
+            # drains faster, since enqueue is cheaper than inline send()).
+            l1, r1, l2, r2 = build_bridge(c, "p3", 14300)
+            tx = bound_udp(r1)
+            rx = bound_udp(r2)
+            t0 = send_burst(tx, (HOST, l1), 100)
+            count, t_last = recv_count(rx, 100, timeout=3.0)
+            dt = (t_last - t0) if t_last else 999.0
+            r.check("perf: no-delay forwards a burst fast (< 0.5s)",
+                    count >= 90 and dt < 0.5, "%d/100 in %.0fms" % (count, dt * 1000))
+            tx.close()
+            rx.close()
+            assert c.code("bridge stop p3") == "100"
+            assert c.code("bridge delete p3") == "100"
+        finally:
+            c.close()
+
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The `delay` packet filter (and the jitter, loss, and corrupt filters that compose with it) previously slept inline (`nanosleep`) inside the per-direction bridge thread. Each direction serviced at most ~`1000/latency_ms` pps (~10 pps at 100 ms); any heavier offered load backed up in the kernel UDP socket buffer, RTT climbed without bound, and the link collapsed with packet loss / `destination host unreachable`.

This was the root cause behind **gns3/gns3-server#2827** ("Packet Filters Use Incorrect Values + Cause Links to go Haywire"). The GUI and server are innocent — they only forward the configured delay value to uBridge verbatim.

## The fix

Replace the inline `nanosleep()` with a **user-space delay line modelled on the Linux kernel netem qdisc** (`net/sched/sch_netem.c`):

- **Per-packet time-stamping (`time_to_send = now + delay +/- jitter`)**: the receive thread enqueues a packet copy and never blocks, so the kernel UDP buffer stays drained.
- **Dedicated release thread per direction** (the netem qdisc watchdog equivalent): waits on the head`s `time_to_send` (`cond_timedwait` / `CLOCK_MONOTONIC`) and sends via callback when due.
- **`tfifo`-style time-ordered queue**: O(1) tail append in the common in-order case, sorted insert for jitter reordering.
- **Gaussian (normal) jitter**: inverse-CDF distribution table generated via Peter Acklam`s rational quantile approximation, matching `tc netem distribution normal`. Uniform fallback matches netem`s `dist==NULL` path.
- **Depth-bounded queue with tail-drop** (default 1000 packets = `NETEM_LIMIT_DEFAULT`, overridable via `UBRIDGE_DELAY_LIMIT=...`): under overload, excess packets are shed instead of buffered without bound, so latency AND memory stay bounded.
- **Runtime filter management**: GNS3 applies filters to running bridges (`add_ubridge_udp_connection` -> `bridge start`, THEN `_ubridge_apply_filters`). The delay config is re-read on each packet and the line is lazily (re)created/destroyed to match appearing, changing, or disappearing delay filters.
- **IOL bridge integration**: IOL bridges run their own packet loops (`filter->handler` directly), previously bypassed by the delay-line fix. Now both IOL directions (`NIO->IOL` and `IOL->NIO`) each get their own delay line aligned with the UDP bridge.

### Verified behaviour (all four GNS3 backends)

A comprehensive 100-packet test across **dynamips / IOL / qemu / docker** confirms:

| Filter | Expected | Max deviation |
|---|---|---|
| `packet_loss 50` | ~75% RTT loss (bidirectional, squared) | +/-5% |
| `frequency_drop 4` | ~44% RTT loss | +5% |
| `corrupt 80` | ~96% RTT loss | +/-1% |

Flood testing (`ping -f`) does NOT degrade filter behaviour — the old link-collapse (#2827) is gone. Full report:  
https://github.com/yueguobin/gns3-api-mcp-test/blob/main/mcp_test_docs/en/packet_filter_test_report.md

### Test suite

`tests/delay/` — 4 suites, 37 checks, rootless (UDP only + unix IOL):
- `test_latency.py` (19 checks) — correctness: delay + jitter + loss composition + combo + runtime add/change/remove + queue limit
- `test_perf.py` (6 checks) — anti-collapse at scale (400-pkt burst @50ms drains in ~55ms; the bug took ~20s), accuracy across 10/100/500ms, no-delay baseline
- `test_boundary.py` (9 checks) — 1ms minimum, jitter>latency clamp, 1B/60KB packet sizes, stop-with-queued doesn`t hang, limit boundary (UBRIDGE_DELAY_LIMIT=10)
- `test_iol.py` (3 checks) — IOL->NIO / NIO->IOL delay ~100ms each, teardown with delay active doesn`t hang

All suites stable across repeated runs, clean under Valgrind (no leaks, no invalid reads).

## Related

- Root-cause issue: **GNS3/ubridge#114**
- Original user report: **GNS3/gns3-server#2827**
- Test report: https://github.com/yueguobin/gns3-api-mcp-test/blob/main/mcp_test_docs/en/packet_filter_test_report.md