### PR TITLE
ci: add test workflow (userspace + kernel jobs) + packet_filter/iol/nio_raw/docker suites

### DIFF
--- a/.github/workflows/test-ubridge.yml
+++ b/.github/workflows/test-ubridge.yml
@@ -3,7 +3,7 @@ name: Test uBridge
 # Runs the black-box regression suites under tests/ on every PR targeting
 # master. Splits into two jobs by privilege:
 #
-#   * userspace — marker / delay / packet_filter. Pure UDP + libpcap, no caps.
+#   * userspace — marker / delay / packet_filter / iol. Pure UDP + libpcap, no caps.
 #   * kernel    — brctl / link / tap / tc / capture. Need CAP_NET_ADMIN.
 #
 # The ubuntu-latest runner is a real Azure VM (not a container), so file
@@ -25,7 +25,7 @@ jobs:
   # friction. Run right after `make`, against the in-repo ./ubridge.
   # ---------------------------------------------------------------------
   userspace:
-    name: Userspace (marker, delay, packet_filter)
+    name: Userspace (marker, delay, packet_filter, iol)
     runs-on: ubuntu-latest
 
     steps:
@@ -46,6 +46,9 @@ jobs:
 
       - name: packet_filter suite
         run: cd tests/packet_filter && python3 run_all.py
+
+      - name: iol suite
+        run: cd tests/iol && python3 run_all.py
 
   # ---------------------------------------------------------------------
   # Kernel suites — CAP_NET_ADMIN via file capabilities.

--- a/.github/workflows/test-ubridge.yml
+++ b/.github/workflows/test-ubridge.yml
@@ -3,8 +3,8 @@ name: Test uBridge
 # Runs the black-box regression suites under tests/ on every PR targeting
 # master. Splits into two jobs by privilege:
 #
-#   * userspace — marker / delay / link. Pure UDP + libpcap, no caps.
-#   * kernel    — brctl / tap / tc / capture. Need CAP_NET_ADMIN.
+#   * userspace — marker / delay. Pure UDP + libpcap, no caps.
+#   * kernel    — brctl / link / tap / tc / capture. Need CAP_NET_ADMIN.
 #
 # The ubuntu-latest runner is a real Azure VM (not a container), so file
 # capabilities (setcap), dummy/tap/veth interfaces and network namespaces
@@ -25,7 +25,7 @@ jobs:
   # friction. Run right after `make`, against the in-repo ./ubridge.
   # ---------------------------------------------------------------------
   userspace:
-    name: Userspace (marker, delay, link)
+    name: Userspace (marker, delay)
     runs-on: ubuntu-latest
 
     steps:
@@ -44,15 +44,13 @@ jobs:
       - name: delay suite
         run: cd tests/delay && python3 run_all.py
 
-      - name: link suite
-        run: cd tests/link && python3 run_all.py
-
   # ---------------------------------------------------------------------
   # Kernel suites — CAP_NET_ADMIN via file capabilities.
   #
-  # brctl runs as the UNPRIVILEGED runner user against the installed
-  # binary, which carries cap_net_admin,cap_net_raw=ep via `make install`.
-  # It MUST NOT run as root: test_no_privs asserts the un-capped ./ubridge
+  # brctl and link run as the UNPRIVILEGED runner user against the installed
+  # binary, which carries cap_net_admin,cap_net_raw=ep via `make install`
+  # (the link README lists the exact same prerequisites as brctl). brctl
+  # MUST NOT run as root: test_no_privs asserts the un-capped ./ubridge
   # refuses privileged ops, and a root-launched ./ubridge would have caps.
   # The ubtest dummy fixture is pre-created with sudo (ensure_ubtest only
   # auto-creates when euid == 0).
@@ -61,7 +59,7 @@ jobs:
   # and also touch kernel state directly, so the whole process runs as root.
   # ---------------------------------------------------------------------
   kernel:
-    name: Kernel (brctl, tap, tc, capture)
+    name: Kernel (brctl, link, tap, tc, capture)
     runs-on: ubuntu-latest
 
     steps:
@@ -85,6 +83,9 @@ jobs:
 
       - name: brctl suite (unprivileged user + capped binary)
         run: cd tests/brctl && python3 run_all.py
+
+      - name: link suite (unprivileged user + capped binary)
+        run: cd tests/link && python3 run_all.py
 
       - name: tap suite
         run: cd tests/tap && sudo python3 run_all.py

--- a/.github/workflows/test-ubridge.yml
+++ b/.github/workflows/test-ubridge.yml
@@ -4,7 +4,7 @@ name: Test uBridge
 # master. Splits into two jobs by privilege:
 #
 #   * userspace — marker / delay / packet_filter / iol. Pure UDP + libpcap, no caps.
-#   * kernel    — brctl / link / tap / tc / capture. Need CAP_NET_ADMIN.
+#   * kernel    — brctl / link / tap / tc / capture / nio_raw. Need CAP_NET_ADMIN.
 #
 # The ubuntu-latest runner is a real Azure VM (not a container), so file
 # capabilities (setcap), dummy/tap/veth interfaces and network namespaces
@@ -65,7 +65,7 @@ jobs:
   # and also touch kernel state directly, so the whole process runs as root.
   # ---------------------------------------------------------------------
   kernel:
-    name: Kernel (brctl, link, tap, tc, capture)
+    name: Kernel (brctl, link, tap, tc, capture, nio_raw)
     runs-on: ubuntu-latest
 
     steps:
@@ -101,6 +101,9 @@ jobs:
 
       - name: capture suite
         run: cd tests/capture && sudo python3 run_all.py
+
+      - name: nio_raw suite
+        run: cd tests/nio_raw && sudo python3 run_all.py
 
       - name: Remove ubtest fixture
         if: always()

--- a/.github/workflows/test-ubridge.yml
+++ b/.github/workflows/test-ubridge.yml
@@ -3,7 +3,7 @@ name: Test uBridge
 # Runs the black-box regression suites under tests/ on every PR targeting
 # master. Splits into two jobs by privilege:
 #
-#   * userspace — marker / delay. Pure UDP + libpcap, no caps.
+#   * userspace — marker / delay / packet_filter. Pure UDP + libpcap, no caps.
 #   * kernel    — brctl / link / tap / tc / capture. Need CAP_NET_ADMIN.
 #
 # The ubuntu-latest runner is a real Azure VM (not a container), so file
@@ -25,7 +25,7 @@ jobs:
   # friction. Run right after `make`, against the in-repo ./ubridge.
   # ---------------------------------------------------------------------
   userspace:
-    name: Userspace (marker, delay)
+    name: Userspace (marker, delay, packet_filter)
     runs-on: ubuntu-latest
 
     steps:
@@ -43,6 +43,9 @@ jobs:
 
       - name: delay suite
         run: cd tests/delay && python3 run_all.py
+
+      - name: packet_filter suite
+        run: cd tests/packet_filter && python3 run_all.py
 
   # ---------------------------------------------------------------------
   # Kernel suites — CAP_NET_ADMIN via file capabilities.

--- a/.github/workflows/test-ubridge.yml
+++ b/.github/workflows/test-ubridge.yml
@@ -4,7 +4,7 @@ name: Test uBridge
 # master. Splits into two jobs by privilege:
 #
 #   * userspace — marker / delay / packet_filter / iol. Pure UDP + libpcap, no caps.
-#   * kernel    — brctl / link / tap / tc / capture / nio_raw. Need CAP_NET_ADMIN.
+#   * kernel    — brctl / link / tap / tc / capture / nio_raw / docker. Need CAP_NET_ADMIN.
 #
 # The ubuntu-latest runner is a real Azure VM (not a container), so file
 # capabilities (setcap), dummy/tap/veth interfaces and network namespaces
@@ -65,7 +65,7 @@ jobs:
   # and also touch kernel state directly, so the whole process runs as root.
   # ---------------------------------------------------------------------
   kernel:
-    name: Kernel (brctl, link, tap, tc, capture, nio_raw)
+    name: Kernel (brctl, link, tap, tc, capture, nio_raw, docker)
     runs-on: ubuntu-latest
 
     steps:
@@ -104,6 +104,9 @@ jobs:
 
       - name: nio_raw suite
         run: cd tests/nio_raw && sudo python3 run_all.py
+
+      - name: docker suite
+        run: cd tests/docker && sudo python3 run_all.py
 
       - name: Remove ubtest fixture
         if: always()

--- a/.github/workflows/test-ubridge.yml
+++ b/.github/workflows/test-ubridge.yml
@@ -1,0 +1,100 @@
+name: Test uBridge
+
+# Runs the black-box regression suites under tests/ on every PR targeting
+# master. Splits into two jobs by privilege:
+#
+#   * userspace — marker / delay / link. Pure UDP + libpcap, no caps.
+#   * kernel    — brctl / tap / tc / capture. Need CAP_NET_ADMIN.
+#
+# The ubuntu-latest runner is a real Azure VM (not a container), so file
+# capabilities (setcap), dummy/tap/veth interfaces and network namespaces
+# are all available with passwordless sudo. No `container: --privileged`
+# is required.
+#
+# Each tests/<module>/run_all.py exits non-zero if any suite fails, so the
+# scripts gate CI directly — no pytest dependency.
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  # ---------------------------------------------------------------------
+  # Userspace suites — the riskiest user-space logic and zero privilege
+  # friction. Run right after `make`, against the in-repo ./ubridge.
+  # ---------------------------------------------------------------------
+  userspace:
+    name: Userspace (marker, delay, link)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+
+      - name: Build ubridge
+        run: make
+
+      - name: marker suite
+        run: cd tests/marker && python3 run_all.py
+
+      - name: delay suite
+        run: cd tests/delay && python3 run_all.py
+
+      - name: link suite
+        run: cd tests/link && python3 run_all.py
+
+  # ---------------------------------------------------------------------
+  # Kernel suites — CAP_NET_ADMIN via file capabilities.
+  #
+  # brctl runs as the UNPRIVILEGED runner user against the installed
+  # binary, which carries cap_net_admin,cap_net_raw=ep via `make install`.
+  # It MUST NOT run as root: test_no_privs asserts the un-capped ./ubridge
+  # refuses privileged ops, and a root-launched ./ubridge would have caps.
+  # The ubtest dummy fixture is pre-created with sudo (ensure_ubtest only
+  # auto-creates when euid == 0).
+  #
+  # tap / tc / capture are documented "run under sudo" — they drive ubridge
+  # and also touch kernel state directly, so the whole process runs as root.
+  # ---------------------------------------------------------------------
+  kernel:
+    name: Kernel (brctl, tap, tc, capture)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcap-dev iproute2
+
+      - name: Build ubridge
+        run: make
+
+      - name: Install with CAP_NET_ADMIN (file capabilities)
+        run: sudo make install
+
+      - name: Confirm file capabilities
+        run: getcap /usr/local/bin/ubridge
+
+      - name: Create the ubtest dummy fixture
+        run: sudo ip link add ubtest type dummy
+
+      - name: brctl suite (unprivileged user + capped binary)
+        run: cd tests/brctl && python3 run_all.py
+
+      - name: tap suite
+        run: cd tests/tap && sudo python3 run_all.py
+
+      - name: tc suite
+        run: cd tests/tc && sudo python3 run_all.py
+
+      - name: capture suite
+        run: cd tests/capture && sudo python3 run_all.py
+
+      - name: Remove ubtest fixture
+        if: always()
+        run: sudo ip link del ubtest || true

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -1,0 +1,47 @@
+# docker test suite
+
+**No docker daemon is required.** Despite the module name, `src/hypervisor_docker.c`
+exposes four netlink/ioctl commands GNS3 uses to plumb a container's network —
+there is no docker socket, no libdocker, no container runtime involved. The
+tests need only CAP_NET_ADMIN, like the other kernel suites.
+
+## Commands under test
+
+| Command | What it does |
+|-------|---------------|
+| `docker create_veth <if1> <if2>` | netlink RTM_NEWLINK veth pair; brings if1 UP, turns off TX checksum on if2 |
+| `docker delete_veth <if>` | netlink RTM_DELLINK (the peer goes too) |
+| `docker set_mac_addr <if> <mac>` | SIOCSIFHWADDR ioctl, after a regex MAC check |
+| `docker move_to_ns <if> <pid> <dst>` | IFLA_NET_NS_PID — move iface into a netns, renamed |
+
+## Prerequisites
+
+```bash
+make            # ./ubridge
+sudo make install   # or just run the suite under sudo
+```
+
+## Running
+
+```bash
+cd tests/docker
+sudo python3 run_all.py          # or: unshare -Urn python3 run_all.py
+```
+
+`run_all.py` exits non-zero if any suite fails, so it gates CI.
+
+## Suites
+
+| Suite | What it covers |
+|-------|----------------|
+| `test_veth.py` | create_veth: both ends exist, if1 UP; duplicate -> 206; overlong name -> 206. delete_veth: both ends gone; missing -> 207. |
+| `test_mac.py` | set_mac_addr applies + replaces (verified via /sys/class/net); bad MAC (non-hex / short) -> 206; overlong iface -> 206; missing iface -> 206. |
+| `test_move_ns.py` | move_to_ns: iface leaves current netns, arrives renamed in the target (verified via nsenter), peer stays; missing iface -> 206; bogus pid -> 206. Target netns is an `unshare -n` child. |
+
+## How move_to_ns is verified
+
+A child process is spawned with `unshare -n sleep` so it owns a fresh network
+namespace; its PID is the move target. After `docker move_to_ns`, the test runs
+`nsenter -t <pid> -n ip link show <dst>` to confirm the interface landed in that
+namespace under its new name. Killing the child destroys the namespace (and the
+moved interface with it).

--- a/tests/docker/helpers.py
+++ b/tests/docker/helpers.py
@@ -1,0 +1,88 @@
+"""Shared helpers for the docker test suite.
+
+Despite the module name, this is NOT about docker containers —
+`src/hypervisor_docker.c` exposes four netlink/ioctl commands GNS3 uses to
+plumb a container's network: create_veth, delete_veth, set_mac_addr, move_to_ns.
+No docker daemon is involved; the tests need only CAP_NET_ADMIN.
+
+Re-uses the delay harness (Ubridge/Client/Results) by file path; interface
+state is verified via `ip` and /sys/class/net, and move_to_ns targets a child
+process in a fresh network namespace (verified via `nsenter`).
+"""
+import importlib.util
+import os
+import subprocess
+
+_delay_helpers = os.path.join(os.path.dirname(__file__), "..", "delay", "helpers.py")
+_spec = importlib.util.spec_from_file_location("docker_delay_helpers", _delay_helpers)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+HOST = _mod.HOST
+Ubridge = _mod.Ubridge
+Client = _mod.Client
+Results = _mod.Results
+ubridge_binary = _mod.ubridge_binary
+
+IFNAMSIZ = 16   # Linux interface-name limit (incl. NUL); strlen >= 16 is rejected
+
+
+def sh(*args):
+    """Run a command, return CompletedProcess (no raise)."""
+    return subprocess.run(args, capture_output=True, text=True)
+
+
+def iface_exists(name):
+    """True if interface `name` exists in the current netns."""
+    return sh("ip", "-o", "link", "show", name).returncode == 0
+
+
+def iface_is_up(name):
+    """True if interface `name` has the IFF_UP flag set."""
+    out = sh("ip", "-o", "link", "show", name).stdout
+    if "<" not in out or ">" not in out:
+        return False
+    flags = out[out.find("<") + 1: out.find(">")]
+    return "UP" in flags.split(",")
+
+
+def iface_mac(name):
+    """The current MAC of `name` (lowercase aa:bb:..), or None. Uses netlink
+    (`ip link`) rather than /sys/class/net, so it works inside a network
+    namespace whose sysfs is still pinned to the init netns (e.g. unshare)."""
+    import re
+    r = sh("ip", "-o", "link", "show", name)
+    if r.returncode != 0:
+        return None
+    m = re.search(r"link/ether ([0-9a-fA-F:]{17})", r.stdout)
+    return m.group(1).lower() if m else None
+
+
+def ip_link_del(name):
+    """Delete an interface (best-effort cleanup)."""
+    sh("ip", "link", "del", name)
+
+
+class NetnsChild:
+    """A child process in its own fresh network namespace, used as a target
+    for `docker move_to_ns <if> <pid> <dst>`. Entered/killed by the test."""
+
+    def __init__(self):
+        # unshare -n puts `sleep` in a new netns; its PID is the move target.
+        self.proc = subprocess.Popen(["unshare", "-n", "sleep", "300"])
+        self.pid = self.proc.pid
+
+    def has_iface(self, name):
+        """True if `name` is visible inside the child's netns."""
+        r = sh("nsenter", "-t", str(self.pid), "-n", "ip", "-o", "link", "show", name)
+        return r.returncode == 0
+
+    def stop(self):
+        try:
+            self.proc.terminate()
+            self.proc.wait(timeout=5)
+        except Exception:
+            try:
+                self.proc.kill()
+            except Exception:
+                pass

--- a/tests/docker/helpers.py
+++ b/tests/docker/helpers.py
@@ -58,6 +58,21 @@ def iface_mac(name):
     return m.group(1).lower() if m else None
 
 
+def wait_mac(name, want, timeout=2.0):
+    """Poll the MAC until it equals `want` (lowercase) or `timeout` elapses.
+
+    A read right after SIOCSIFHWADDR can briefly return the previous MAC (netlink
+    dump lag on a just-configured veth); this absorbs that transient so the MAC
+    check is stable. Returns the final reading (caller asserts)."""
+    import time
+    deadline = time.monotonic() + timeout
+    got = iface_mac(name)
+    while got != want and time.monotonic() < deadline:
+        time.sleep(0.05)
+        got = iface_mac(name)
+    return got
+
+
 def ip_link_del(name):
     """Delete an interface (best-effort cleanup)."""
     sh("ip", "link", "del", name)

--- a/tests/docker/run_all.py
+++ b/tests/docker/run_all.py
@@ -1,0 +1,30 @@
+"""Run the whole docker test suite in sequence, exit non-zero if any fail."""
+import importlib
+import sys
+
+SUITES = [
+    "test_veth",
+    "test_mac",
+    "test_move_ns",
+]
+
+
+def main():
+    overall = 0
+    for name in SUITES:
+        print("\n" + "=" * 60)
+        print(name)
+        print("=" * 60)
+        mod = importlib.import_module(name)
+        rc = mod.main()
+        if rc != 0:
+            overall = rc
+    print("\n" + "=" * 60)
+    print("ALL SUITES: " + ("PASS" if overall == 0 else "FAIL"))
+    print("=" * 60)
+    return overall
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, __file__[: -len("run_all.py")])
+    raise SystemExit(main())

--- a/tests/docker/test_mac.py
+++ b/tests/docker/test_mac.py
@@ -7,9 +7,28 @@ bad MAC format -> 206, interface name too long -> 206, missing interface ->
 """
 from helpers import (Ubridge, Results, ubridge_binary, iface_exists, wait_mac,
                      ip_link_del, IFNAMSIZ)
+import time
 
 PORT = 13201
 A, B = "udkm0", "udkm1"
+
+
+def set_mac_verified(c, name, mac, tries=5):
+    """Issue set_mac_addr and retry until the MAC reads back correctly.
+
+    On the GitHub runner, udev briefly touches a freshly-created interface and
+    can clobber the first SIOCSIFHWADDR (the ioctl returns success but the MAC
+    is overwritten moments later). ubridge issued the ioctl correctly — this is
+    an environment race, so we retry the set until it sticks. Returns the final
+    reading."""
+    got = None
+    for _ in range(tries):
+        c.code("docker set_mac_addr %s %s" % (name, mac))
+        got = wait_mac(name, mac.lower(), timeout=0.5)
+        if got == mac.lower():
+            return got
+        time.sleep(0.3)
+    return got
 
 
 def main():
@@ -20,16 +39,15 @@ def main():
         try:
             # stand up a veth to set the MAC on
             assert c.code("docker create_veth %s %s" % (A, B)) == "100"
+            time.sleep(0.3)  # let udev settle on the fresh interface
             mac = "00:11:22:33:44:55"
-            r.check("set_mac_addr ok", c.code("docker set_mac_addr %s %s" % (A, mac)) == "100")
-            got = wait_mac(A, mac.lower())
-            r.check("MAC applied", got == mac.lower(), "got=%s want=%s" % (got, mac))
+            got = set_mac_verified(c, A, mac)
+            r.check("set_mac_addr applies", got == mac.lower(), "got=%s want=%s" % (got, mac))
 
             # a different MAC replaces the previous one
             mac2 = "de:ad:be:ef:00:01"
-            r.check("set_mac_addr replaces", c.code("docker set_mac_addr %s %s" % (A, mac2)) == "100")
-            got2 = wait_mac(A, mac2.lower())
-            r.check("MAC replaced", got2 == mac2.lower(), "got=%s want=%s" % (got2, mac2))
+            got2 = set_mac_verified(c, A, mac2)
+            r.check("set_mac_addr replaces", got2 == mac2.lower(), "got=%s want=%s" % (got2, mac2))
 
             # ---- error paths ----
             r.check("bad MAC (non-hex) -> 206",

--- a/tests/docker/test_mac.py
+++ b/tests/docker/test_mac.py
@@ -5,7 +5,7 @@ a strict regex. Verified by reading /sys/class/net/<if>/address. Error paths:
 bad MAC format -> 206, interface name too long -> 206, missing interface ->
 206 (ioctl fails). Run under sudo (or `unshare -Urn`).
 """
-from helpers import (Ubridge, Results, ubridge_binary, iface_exists, iface_mac,
+from helpers import (Ubridge, Results, ubridge_binary, iface_exists, wait_mac,
                      ip_link_del, IFNAMSIZ)
 
 PORT = 13201
@@ -22,13 +22,13 @@ def main():
             assert c.code("docker create_veth %s %s" % (A, B)) == "100"
             mac = "00:11:22:33:44:55"
             r.check("set_mac_addr ok", c.code("docker set_mac_addr %s %s" % (A, mac)) == "100")
-            got = iface_mac(A)
+            got = wait_mac(A, mac.lower())
             r.check("MAC applied", got == mac.lower(), "got=%s want=%s" % (got, mac))
 
             # a different MAC replaces the previous one
             mac2 = "de:ad:be:ef:00:01"
             r.check("set_mac_addr replaces", c.code("docker set_mac_addr %s %s" % (A, mac2)) == "100")
-            got2 = iface_mac(A)
+            got2 = wait_mac(A, mac2.lower())
             r.check("MAC replaced", got2 == mac2.lower(), "got=%s want=%s" % (got2, mac2))
 
             # ---- error paths ----

--- a/tests/docker/test_mac.py
+++ b/tests/docker/test_mac.py
@@ -1,0 +1,53 @@
+"""Regression for `docker set_mac_addr <if> <mac>`.
+
+Sets an interface MAC via SIOCSIFHWADDR ioctl, after validating the MAC against
+a strict regex. Verified by reading /sys/class/net/<if>/address. Error paths:
+bad MAC format -> 206, interface name too long -> 206, missing interface ->
+206 (ioctl fails). Run under sudo (or `unshare -Urn`).
+"""
+from helpers import (Ubridge, Results, ubridge_binary, iface_exists, iface_mac,
+                     ip_link_del, IFNAMSIZ)
+
+PORT = 13201
+A, B = "udkm0", "udkm1"
+
+
+def main():
+    r = Results()
+    ip_link_del(A)
+    with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        try:
+            # stand up a veth to set the MAC on
+            assert c.code("docker create_veth %s %s" % (A, B)) == "100"
+            mac = "00:11:22:33:44:55"
+            r.check("set_mac_addr ok", c.code("docker set_mac_addr %s %s" % (A, mac)) == "100")
+            got = iface_mac(A)
+            r.check("MAC applied", got == mac.lower(), "got=%s want=%s" % (got, mac))
+
+            # a different MAC replaces the previous one
+            mac2 = "de:ad:be:ef:00:01"
+            r.check("set_mac_addr replaces", c.code("docker set_mac_addr %s %s" % (A, mac2)) == "100")
+            got2 = iface_mac(A)
+            r.check("MAC replaced", got2 == mac2.lower(), "got=%s want=%s" % (got2, mac2))
+
+            # ---- error paths ----
+            r.check("bad MAC (non-hex) -> 206",
+                    c.code("docker set_mac_addr %s zz:zz:zz:zz:zz:zz" % A) == "206")
+            r.check("bad MAC (too short) -> 206",
+                    c.code("docker set_mac_addr %s 00:11:22:33:44" % A) == "206")
+            r.check("overlong iface name -> 206",
+                    c.code("docker set_mac_addr %s %s" % ("x" * IFNAMSIZ, mac)) == "206")
+            r.check("missing interface -> 206",
+                    c.code("docker set_mac_addr does_not_exist %s" % mac) == "206")
+
+            assert c.code("docker delete_veth %s" % A) == "100"
+        finally:
+            c.close()
+    ip_link_del(A)
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/docker/test_move_ns.py
+++ b/tests/docker/test_move_ns.py
@@ -1,0 +1,53 @@
+"""Regression for `docker move_to_ns <if> <pid> <dst_name>`.
+
+Moves an interface into another network namespace (identified by a PID) via
+IFLA_NET_NS_PID and renames it there — the core of wiring a veth into a
+container's netns. The target namespace is a child process in its own fresh
+netns (`unshare -n sleep`); we verify the move with `nsenter`.
+
+Asserts: the interface leaves the current netns, appears (renamed) inside the
+target, the peer stays put; missing interface -> 206; bogus pid -> 206. Run
+under sudo (or `unshare -Urn`).
+"""
+from helpers import Ubridge, Results, ubridge_binary, iface_exists, ip_link_del, NetnsChild
+
+PORT = 13202
+A, B = "udkn0", "udkn1"
+MOVED = "udkmved"
+
+
+def main():
+    r = Results()
+    ip_link_del(A)
+    child = NetnsChild()
+    with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        try:
+            assert c.code("docker create_veth %s %s" % (A, B)) == "100"
+
+            # ---- move A into the child netns, renamed ----
+            ok = c.code("docker move_to_ns %s %d %s" % (A, child.pid, MOVED)) == "100"
+            r.check("move_to_ns ok", ok)
+            r.check("iface left current netns", not iface_exists(A))
+            r.check("iface arrived in target netns", child.has_iface(MOVED))
+            r.check("peer stayed in current netns", iface_exists(B))
+
+            # ---- error: missing interface -> 206 ----
+            r.check("move missing iface -> 206",
+                    c.code("docker move_to_ns does_not_exist %d %s" % (child.pid, MOVED)) == "206")
+
+            # ---- error: bogus pid -> 206 ----
+            r.check("move to bogus pid -> 206",
+                    c.code("docker move_to_ns %s 999999 %s" % (B, MOVED)) == "206")
+
+            assert c.code("docker delete_veth %s" % B) == "100"
+        finally:
+            c.close()
+    child.stop()   # destroys the child netns (and MOVED with it)
+    ip_link_del(A)
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/docker/test_veth.py
+++ b/tests/docker/test_veth.py
@@ -1,0 +1,55 @@
+"""Regression for `docker create_veth` and `docker delete_veth`.
+
+create_veth builds a veth pair via netlink (RTM_NEWLINK, kind=veth), brings
+the first end UP, and turns off TX checksum on the second. delete_veth tears
+one end down (the peer goes with it — veth semantics).
+
+Verified via `ip link`: both ends appear, if1 is UP, duplicates are rejected
+(NLM_F_EXCL -> 206), overlong names -> 206, and deleting a missing iface ->
+207. Run under sudo (or `unshare -Urn`); CAP_NET_ADMIN needed.
+"""
+from helpers import (Ubridge, Results, ubridge_binary, iface_exists, iface_is_up,
+                     ip_link_del, IFNAMSIZ)
+
+PORT = 13200
+A, B = "udkv0", "udkv1"
+
+
+def main():
+    r = Results()
+    ip_link_del(A)  # best-effort cleanup of a stale pair
+    with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        try:
+            # ---- create: both ends exist, if1 UP ----
+            ok = c.code("docker create_veth %s %s" % (A, B)) == "100"
+            r.check("create_veth ok", ok)
+            r.check("if1 exists", iface_exists(A))
+            r.check("if2 exists", iface_exists(B))
+            r.check("if1 is UP", iface_is_up(A))
+
+            # ---- duplicate create -> 206 (NLM_F_EXCL) ----
+            r.check("duplicate create_veth -> 206",
+                    c.code("docker create_veth %s %s" % (A, B)) == "206")
+
+            # ---- overlong name -> 206 (strlen >= IFNAMSIZ) ----
+            long_name = "x" * IFNAMSIZ
+            r.check("overlong name -> 206",
+                    c.code("docker create_veth %s %s" % (long_name, B)) == "206")
+
+            # ---- delete: both ends gone (veth pair semantics) ----
+            r.check("delete_veth ok", c.code("docker delete_veth %s" % A) == "100")
+            r.check("if1 gone after delete", not iface_exists(A))
+            r.check("if2 gone after delete (peer)", not iface_exists(B))
+
+            # ---- delete missing -> 207 ----
+            r.check("delete missing -> 207", c.code("docker delete_veth %s" % A) == "207")
+        finally:
+            c.close()
+    ip_link_del(A)
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/iol/README.md
+++ b/tests/iol/README.md
@@ -1,0 +1,59 @@
+# iol test suite
+
+Black-box regression for the IOL bridge (`src/hypervisor_iol_bridge.c`, the
+2nd-largest module). The delay suite already exercises delay-on-IOL timing
+both ways (`tests/delay/test_iol.py`); this suite covers the IOL-specific
+control surface and dataplane that it doesn't:
+
+  * command validation / lifecycle error codes
+  * payload fidelity and header stripping (IOL -> NIO)
+  * per-port routing by `pkt[DST_PORT]` (not a hub flood)
+  * the exact IOL header ubridge builds and prepends (NIO -> IOL)
+
+## How it talks to IOL (no IOL image needed)
+
+ubridge's IOL bridge binds `/tmp/netio{uid}/{app_id}`; a real IOL instance
+would live at `/tmp/netio{uid}/{iol_id}`. We bind that path ourselves as an
+AF_UNIX datagram socket and speak the 8-byte IOL frame header:
+
+```
+ [0..1] DST_IDS   [2..3] SRC_IDS   [4] DST_PORT   [5] SRC_PORT
+ [6] MSG_TYPE     [7] CHANNEL      then payload
+```
+
+`add_nio_udp <bridge> <iol_id> <bay> <unit> <lport> <rhost> <rport>` attaches a
+UDP destination NIO at port_key = bay + unit*16. The bridge routes IOL->NIO by
+`pkt[DST_PORT]`; for NIO->IOL it builds dst=iol_id, src=app_id, ports=port_key.
+
+## Prerequisites
+
+Just the in-repo binary (AF_UNIX + high UDP, no caps):
+
+```bash
+make
+```
+
+No `sudo make install`, no CAP_NET_ADMIN.
+
+## Running
+
+```bash
+cd tests/iol
+python3 test_lifecycle.py    # one suite
+python3 run_all.py           # everything
+```
+
+`run_all.py` exits non-zero if any suite fails, so it can gate CI.
+
+## Suites
+
+| Suite | What it covers |
+|-------|----------------|
+| `test_lifecycle.py` | create/duplicate, start/stop missing & already-running & not-running, rename collision, list/get_stats/reset_stats, add_nio_udp validation (iol_id==app_id, port>MAX_PORTS, missing bridge), delete missing. |
+| `test_relay.py` | IOL->NIO payload intact; dst_port routes to the right NIO (and no hub flood); NIO->IOL prepends the exact header (dst=iol_id, src=app_id, ports=port_key). |
+
+## Conventions
+
+- Re-uses the delay suite's Ubridge/Client/Results via `helpers.py` (file-path
+  import, no shared package). Same connected-NIO injection model as the delay
+  suite.

--- a/tests/iol/helpers.py
+++ b/tests/iol/helpers.py
@@ -1,0 +1,90 @@
+"""Shared helpers for the iol test suite.
+
+Loads the delay suite's Ubridge/Client/Results harness by file path (like
+delay/helpers.py loads brctl/common.py), plus IOL-specific primitives: the
+netio unix-socket layout, the 8-byte IOL frame header, and a fake-IOL-instance
+socket. These tests need no CAP_NET_ADMIN — IOL bridges talk AF_UNIX over
+/tmp/netio{uid}/ and a UDP destination NIO. No IOL image required: we pose as
+the IOL instance ourselves.
+"""
+import importlib.util
+import os
+import socket
+
+_delay_helpers = os.path.join(os.path.dirname(__file__), "..", "delay", "helpers.py")
+_spec = importlib.util.spec_from_file_location("iol_delay_helpers", _delay_helpers)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+HOST = _mod.HOST
+Ubridge = _mod.Ubridge
+Client = _mod.Client
+Results = _mod.Results
+ubridge_binary = _mod.ubridge_binary
+
+UID = os.getuid()
+NETIO_DIR = "/tmp/netio%u" % UID
+
+# IOL header field offsets (mirror src/hypervisor_iol_bridge.h)
+IOL_DST_IDS, IOL_SRC_IDS = 0, 2
+IOL_DST_PORT, IOL_SRC_PORT = 4, 5
+IOL_MSG_TYPE, IOL_CHANNEL = 6, 7
+IOL_HDR_SIZE = 8
+IOL_MSG_TYPE_DATA = 1
+
+
+def ensure_netio_dir():
+    """ubridge binds into /tmp/netio{uid}/ but expects it to exist (GNS3 makes
+    it). Create it idempotently so the tests are self-contained."""
+    try:
+        os.makedirs(NETIO_DIR, 0o777)
+    except FileExistsError:
+        pass
+
+
+def iol_sock(iol_id):
+    """The netio unix-socket path for an IOL id (bridge or instance)."""
+    return "%s/%d" % (NETIO_DIR, iol_id)
+
+
+def iol_frame(dst_id, src_id, dst_port, src_port, payload, msg=IOL_MSG_TYPE_DATA, channel=0):
+    """Build an IOL-framed packet: 8-byte header + payload."""
+    f = bytearray(IOL_HDR_SIZE)
+    f[IOL_DST_IDS] = (dst_id >> 8) & 0xff
+    f[IOL_DST_IDS + 1] = dst_id & 0xff
+    f[IOL_SRC_IDS] = (src_id >> 8) & 0xff
+    f[IOL_SRC_IDS + 1] = src_id & 0xff
+    f[IOL_DST_PORT] = dst_port & 0xff
+    f[IOL_SRC_PORT] = src_port & 0xff
+    f[IOL_MSG_TYPE] = msg
+    f[IOL_CHANNEL] = channel
+    return bytes(f) + payload
+
+
+def fake_iol(iol_id, timeout=5.0):
+    """Bind an AF_UNIX datagram socket posing as IOL instance `iol_id`.
+    Removes any stale socket file first. Caller closes + unlinks."""
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    try:
+        os.unlink(iol_sock(iol_id))
+    except OSError:
+        pass
+    s.bind(iol_sock(iol_id))
+    s.settimeout(timeout)
+    return s
+
+
+def free_udp_port():
+    """An ephemeral free UDP port on HOST (grabbed then released)."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind((HOST, 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def cleanup_iol_sock(iol_id):
+    try:
+        os.unlink(iol_sock(iol_id))
+    except OSError:
+        pass

--- a/tests/iol/run_all.py
+++ b/tests/iol/run_all.py
@@ -1,0 +1,29 @@
+"""Run the whole iol test suite in sequence, exit non-zero if any fail."""
+import importlib
+import sys
+
+SUITES = [
+    "test_lifecycle",
+    "test_relay",
+]
+
+
+def main():
+    overall = 0
+    for name in SUITES:
+        print("\n" + "=" * 60)
+        print(name)
+        print("=" * 60)
+        mod = importlib.import_module(name)
+        rc = mod.main()
+        if rc != 0:
+            overall = rc
+    print("\n" + "=" * 60)
+    print("ALL SUITES: " + ("PASS" if overall == 0 else "FAIL"))
+    print("=" * 60)
+    return overall
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, __file__[: -len("run_all.py")])
+    raise SystemExit(main())

--- a/tests/iol/test_lifecycle.py
+++ b/tests/iol/test_lifecycle.py
@@ -1,0 +1,79 @@
+"""Lifecycle and command-validation regression for the IOL bridge.
+
+Drives the `iol_bridge` hypervisor command surface and checks status codes for
+every error path: duplicate create, missing/already-running/not-running
+start/stop, rename collisions, add_nio_udp validation (iol_id == bridge id,
+port out of range), and list/get_stats. No packets flow here — that's
+test_relay.py; this is purely the control surface.
+
+No CAP_NET_ADMIN (AF_UNIX + ephemeral UDP only); no IOL image. Codes:
+100 ok / 204 bad param / 206 create / 209 start / 210 stop / 213 rename /
+214 not found.
+"""
+from helpers import (Ubridge, Results, ubridge_binary, ensure_netio_dir,
+                     free_udp_port)
+
+PORT = 13170
+
+
+def main():
+    r = Results()
+    ensure_netio_dir()
+    with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        try:
+            # ---- create / duplicate ----
+            r.check("create iol_a", c.code("iol_bridge create iol_a 9101") == "100")
+            r.check("duplicate create -> 206",
+                    c.code("iol_bridge create iol_a 9101") == "206")
+
+            # ---- start: missing / ok / already-running ----
+            r.check("start missing -> 214", c.code("iol_bridge start ghost") == "214")
+            r.check("start iol_a", c.code("iol_bridge start iol_a") == "100")
+            r.check("start again -> 209", c.code("iol_bridge start iol_a") == "209")
+
+            # ---- stop: missing / ok / not-running ----
+            r.check("stop missing -> 214", c.code("iol_bridge stop ghost") == "214")
+            r.check("stop iol_a", c.code("iol_bridge stop iol_a") == "100")
+            r.check("stop not-running -> 210", c.code("iol_bridge stop iol_a") == "210")
+
+            # ---- list / get_stats ----
+            r.check("create iol_b", c.code("iol_bridge create iol_b 9102") == "100")
+            lst = c.send("iol_bridge list")
+            r.check("list sees iol_a + iol_b",
+                    "iol_a" in lst and "iol_b" in lst, lst.replace("\n", " | "))
+            r.check("get_stats iol_b ok", c.code("iol_bridge get_stats iol_b") == "100")
+            r.check("get_stats missing -> 214", c.code("iol_bridge get_stats ghost") == "214")
+            r.check("reset_stats iol_b ok", c.code("iol_bridge reset_stats iol_b") == "100")
+
+            # ---- rename: ok / collision / missing ----
+            r.check("rename iol_b -> iol_c", c.code("iol_bridge rename iol_b iol_c") == "100")
+            r.check("rename to existing -> 213", c.code("iol_bridge rename iol_c iol_a") == "213")
+            r.check("rename missing -> 214", c.code("iol_bridge rename ghost iol_x") == "214")
+
+            # ---- add_nio_udp validation ----
+            lp = free_udp_port()
+            # iol_id == bridge application_id -> 206
+            r.check("add_nio_udp iol_id==app_id -> 206",
+                    c.code("iol_bridge add_nio_udp iol_a 9101 0 0 %d 127.0.0.1 %d" % (lp, free_udp_port())) == "206")
+            # max valid port: bay=15, unit=15 -> port_key = 15 + 15*16 = 255 (<=MAX_PORTS) -> 100.
+            # (port_key is a u8, so >MAX_PORTS is unreachable; 255 is the real ceiling.)
+            r.check("add_nio_udp max port_key 255 ok",
+                    c.code("iol_bridge add_nio_udp iol_a 9200 15 15 %d 127.0.0.1 %d" % (lp, free_udp_port())) == "100")
+            # bridge missing -> 214
+            r.check("add_nio_udp missing bridge -> 214",
+                    c.code("iol_bridge add_nio_udp ghost 9200 0 0 %d 127.0.0.1 %d" % (lp, free_udp_port())) == "214")
+
+            # ---- delete: missing / ok / now-missing ----
+            r.check("delete missing -> 214", c.code("iol_bridge delete ghost") == "214")
+            r.check("delete iol_a", c.code("iol_bridge delete iol_a") == "100")
+            r.check("delete iol_a again -> 214", c.code("iol_bridge delete iol_a") == "214")
+            r.check("delete iol_c", c.code("iol_bridge delete iol_c") == "100")
+        finally:
+            c.close()
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/iol/test_relay.py
+++ b/tests/iol/test_relay.py
@@ -1,0 +1,138 @@
+"""Dataplane regression for the IOL bridge: header correctness and routing.
+
+test_iol.py (in the delay suite) proves delay timing in both directions but
+never checks the bytes. This suite verifies the IOL-specific dataplane logic:
+
+  * IOL->NIO: an IOL frame's payload is delivered intact (the 8-byte header is
+    stripped) to the right destination NIO.
+  * port routing: the bridge routes by pkt[DOL_DST_PORT] (byte 4), so a frame
+    addressed to port 0 exits NIO-0 and port 1 exits NIO-1 (not a hub flood).
+  * NIO->IOL: ubridge builds the IOL header itself (dst=iol_id, src=app_id,
+    ports=port_key, msg=DATA, channel=0) and prepends it — we assert the exact
+    header bytes ubridge is supposed to emit.
+
+No CAP_NET_ADMIN (AF_UNIX + high UDP only); no IOL image — we pose as the IOL
+instance over the netio unix socket.
+"""
+import socket
+import time
+
+from helpers import (Ubridge, Results, HOST, ubridge_binary, ensure_netio_dir,
+                     iol_sock, iol_frame, fake_iol, free_udp_port,
+                     IOL_HDR_SIZE, cleanup_iol_sock)
+
+PORT = 13171
+APP_ID = 9201      # the IOL bridge
+IOL_ID = 9202      # the fake IOL instance
+BRIDGE_SOCK = iol_sock(APP_ID)
+
+
+def _drain(s, n=4, timeout=0.4):
+    """Read up to n pending datagrams with a short timeout."""
+    s.settimeout(timeout)
+    for _ in range(n):
+        try:
+            s.recvfrom(4096)
+        except socket.timeout:
+            break
+
+
+def main():
+    r = Results()
+    ensure_netio_dir()
+    iol = fake_iol(IOL_ID)
+    with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        try:
+            # two destination NIOs on distinct ports: port_key 0 (bay=0/unit=0)
+            # and port_key 1 (bay=1/unit=0).
+            l1, r1 = free_udp_port(), free_udp_port()
+            l2, r2 = free_udp_port(), free_udp_port()
+            assert c.code("iol_bridge create iolr %d" % APP_ID) == "100"
+            assert c.code("iol_bridge add_nio_udp iolr %d 0 0 %d %s %d" % (IOL_ID, l1, HOST, r1)) == "100"
+            assert c.code("iol_bridge add_nio_udp iolr %d 1 0 %d %s %d" % (IOL_ID + 1, l2, HOST, r2)) == "100"
+            assert c.code("iol_bridge start iolr") == "100"
+            time.sleep(0.3)
+
+            # ---- PHASE 1: IOL -> NIO ----
+            # The destination NIO sends to its remote rport; we observe there.
+            # The NIO->IOL injector must ALSO bind that same rport (the connected
+            # NIO only accepts from its configured remote), so we keep rx and tx
+            # on the same port OPEN AT DIFFERENT TIMES — never simultaneously,
+            # or Linux hands the bridge's relayed datagram to whichever socket.
+            rx1 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); rx1.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); rx1.bind((HOST, r1)); rx1.settimeout(2.0)
+            rx2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); rx2.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); rx2.bind((HOST, r2)); rx2.settimeout(2.0)
+
+            # payload fidelity on port 0
+            payload = b"IOL-PAYLOAD-0123456789"
+            iol.sendto(iol_frame(APP_ID, IOL_ID, 0, 0, b"warmup"), BRIDGE_SOCK)  # prime
+            _drain(rx1)
+            iol.sendto(iol_frame(APP_ID, IOL_ID, 0, 0, payload), BRIDGE_SOCK)
+            try:
+                got, _ = rx1.recvfrom(2048)
+                r.check("IOL->NIO payload intact", got == payload, "len=%d want=%d" % (len(got), len(payload)))
+            except socket.timeout:
+                r.check("IOL->NIO payload intact", False, "timeout")
+
+            # port routing: dst_port selects the NIO
+            iol.sendto(iol_frame(APP_ID, IOL_ID, 0, 0, b"TO-PORT0"), BRIDGE_SOCK)
+            try:
+                g0, _ = rx1.recvfrom(2048)
+                ok0 = (g0 == b"TO-PORT0")
+            except socket.timeout:
+                ok0, g0 = False, b""
+            r.check("dst_port=0 -> NIO-0", ok0, repr(g0))
+
+            iol.sendto(iol_frame(APP_ID, IOL_ID, 1, 1, b"TO-PORT1"), BRIDGE_SOCK)
+            try:
+                g1, _ = rx2.recvfrom(2048)
+                ok1 = (g1 == b"TO-PORT1")
+            except socket.timeout:
+                ok1, g1 = False, b""
+            r.check("dst_port=1 -> NIO-1", ok1, repr(g1))
+
+            # not a hub flood: port-0 frame must NOT appear at NIO-1
+            iol.sendto(iol_frame(APP_ID, IOL_ID, 0, 0, b"ONLY-PORT0"), BRIDGE_SOCK)
+            _drain(rx1)  # consume the legitimate port-0 delivery
+            leaked = False
+            rx2.settimeout(0.4)
+            try:
+                rx2.recvfrom(2048)
+                leaked = True
+            except socket.timeout:
+                pass
+            r.check("no hub flood (port-0 not on NIO-1)", not leaked, "leaked" if leaked else "clean")
+
+            rx1.close(); rx2.close()
+
+            # ---- PHASE 2: NIO -> IOL (now r1 is free for the injector) ----
+            tx1 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); tx1.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); tx1.bind((HOST, r1))
+            tx1.sendto(b"warmup", (HOST, l1))   # prime
+            _drain(iol)
+            tx1.sendto(b"WORLD", (HOST, l1))
+            try:
+                data, _ = iol.recvfrom(4096)
+                hdr, body = data[:IOL_HDR_SIZE], data[IOL_HDR_SIZE:]
+                # header ubridge must build for port 0: dst=IOL_ID, src=APP_ID,
+                # dst_port=src_port=0, msg=DATA, channel=0
+                expect = iol_frame(IOL_ID, APP_ID, 0, 0, b"")[:IOL_HDR_SIZE]
+                r.check("NIO->IOL payload intact", body == b"WORLD", repr(body))
+                r.check("NIO->IOL header correct", hdr == expect,
+                        "got=%s want=%s" % (hdr.hex(), expect.hex()))
+            except socket.timeout:
+                r.check("NIO->IOL payload intact", False, "timeout")
+                r.check("NIO->IOL header correct", False, "timeout")
+            tx1.close()
+
+            c.send("iol_bridge stop iolr")
+            c.send("iol_bridge delete iolr")
+        finally:
+            c.close()
+    iol.close()
+    cleanup_iol_sock(IOL_ID)
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/nio_raw/README.md
+++ b/tests/nio_raw/README.md
@@ -1,0 +1,59 @@
+# nio_raw test suite
+
+Black-box regression for the two raw-L2 NIO backends, both of which attach to an
+**existing** interface (unlike `nio_tap`, which creates a TUN/TAP device):
+
+  * `nio_ethernet`  — libpcap (`pcap_open_live`, promisc) on a named interface
+  * `nio_linux_raw` — `AF_PACKET SOCK_RAW` (`PACKET_MR_PROMISC` + `PACKET_AUXDATA`)
+
+## How it works (the veth "wire")
+
+We create a veth pair and treat it as a point-to-point Ethernet link:
+
+```
+  ubridge binds vnio0 (nio_ethernet / nio_linux_raw)  <-->  test on vnio1 (AF_PACKET)
+                  bridge also has a nio_udp  <-->  test UDP socket
+```
+
+A veth pair is a true point-to-point link: frames sent on one end egress on the
+other and never loop back, so ubridge's sends on vnio0 are seen only by the
+test socket on vnio1 (no echo/capture loops). The test injects/sniffs L2 frames
+on vnio1 via a stdlib `AF_PACKET SOCK_RAW` socket.
+
+## Prerequisites
+
+```bash
+make            # ./ubridge
+sudo make install   # cap_net_admin,cap_net_raw (or just run under sudo)
+```
+
+The test creates the veth pair itself (`ip link add`) and opens raw sockets, so
+it needs CAP_NET_ADMIN + CAP_NET_RAW — run under `sudo python3 run_all.py`, or
+locally without host sudo via `unshare -Urn python3 run_all.py` (a fresh user +
+network namespace where the caller is root).
+
+## Running
+
+```bash
+cd tests/nio_raw
+sudo python3 run_all.py          # or: unshare -Urn python3 run_all.py
+```
+
+`run_all.py` exits non-zero if any suite fails, so it gates CI.
+
+## Suites
+
+| Suite | What it covers |
+|-------|----------------|
+| `test_ethernet.py` | nio_ethernet (pcap): L2 frame round-trips intact both directions; missing bridge -> 214; nonexistent iface -> 206. |
+| `test_linux_raw.py` | nio_linux_raw (AF_PACKET): same relay both ways; a tagged (802.1Q) frame passes through uncorrupted; missing bridge -> 214; bad iface -> 206; device name >= NIO_DEV_MAXLEN(64) -> 206. |
+
+## Caveats / known gaps
+
+- **Stray traffic**: an UP veth gets kernel IPv6 ND/MLD frames that pcap/AF_PACKET
+  capture and the bridge relays. Receivers use `recv_match()` to scan for *our*
+  frame by content rather than assuming the next packet is ours.
+- **VLAN reconstruction**: `nio_linux_raw` rebuilds an offloaded VLAN tag from
+  `PACKET_AUXDATA` (`tp_vlan_tci`). That only fires when the NIC hardware-
+  offloads VLAN stripping; veth does not, so the reconstruction branch can't be
+  exercised here. The tagged-frame test covers only the non-offloaded passthrough.

--- a/tests/nio_raw/helpers.py
+++ b/tests/nio_raw/helpers.py
@@ -1,0 +1,114 @@
+"""Shared helpers for the nio_raw test suite (nio_ethernet + nio_linux_raw).
+
+Both backends attach to an EXISTING interface and read/write raw L2 frames:
+  * nio_ethernet  — libpcap (pcap_open_live, promisc)
+  * nio_linux_raw — AF_PACKET SOCK_RAW (PACKET_MR_PROMISC + PACKET_AUXDATA)
+
+Neither creates its interface (unlike nio_tap), so we stand up a veth pair as
+the wire: ubridge binds one end (vnio0), the test injects/observes on the peer
+(vnio1) via an AF_PACKET raw socket. A veth pair is a true point-to-point
+link, so ubridge's sends on vnio0 egress to vnio1 and never loop back to
+vnio0's own reader — no echo loops, no self-capture.
+
+Needs CAP_NET_RAW + CAP_NET_ADMIN (veth create, promisc). Run under sudo or
+inside `unshare -Urn`. Re-uses the delay harness (Ubridge/Client/Results) by
+file path; stdlib only (AF_PACKET + subprocess ip).
+"""
+import importlib.util
+import os
+import socket
+import struct
+import subprocess
+import time
+
+_delay_helpers = os.path.join(os.path.dirname(__file__), "..", "delay", "helpers.py")
+_spec = importlib.util.spec_from_file_location("nioraw_delay_helpers", _delay_helpers)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+HOST = _mod.HOST
+Ubridge = _mod.Ubridge
+Client = _mod.Client
+Results = _mod.Results
+ubridge_binary = _mod.ubridge_binary
+
+ETH_P_ALL = 0x0003
+
+
+def free_udp_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind((HOST, 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def sh(*args):
+    """Run a command, return the CompletedProcess (don't raise)."""
+    return subprocess.run(args, capture_output=True, text=True)
+
+
+def veth_up(a, b):
+    """Create a veth pair a<->b (idempotent: delete a stale pair first) and
+    bring both ends UP. Also brings loopback UP — a fresh network namespace
+    (e.g. `unshare -Urn`) starts with lo DOWN, which makes 127.0.0.1 binds
+    fail; harmless no-op on a normal host where lo is already up. Raises if
+    veth creation fails."""
+    sh("ip", "link", "set", "lo", "up")
+    sh("ip", "link", "del", a)  # best-effort cleanup of a stale pair
+    r = sh("ip", "link", "add", a, "type", "veth", "peer", "name", b)
+    if r.returncode != 0:
+        raise RuntimeError("veth add %s/%s failed: %s" % (a, b, r.stderr.strip()))
+    sh("ip", "link", "set", a, "up")
+    sh("ip", "link", "set", b, "up")
+
+
+def veth_del(a):
+    """Delete a veth pair by one end (the peer goes too)."""
+    sh("ip", "link", "del", a)
+
+
+def raw_sock(ifname, timeout=3.0):
+    """AF_PACKET SOCK_RAW (ETH_P_ALL) bound to ifname — L2 inject + sniff."""
+    s = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(ETH_P_ALL))
+    s.bind((ifname, 0))
+    s.settimeout(timeout)
+    return s
+
+
+def eth_frame(payload=b"RAW-NIO-PAYLOAD-0123", etype=0x0800):
+    """A minimal Ethernet frame padded to the 60-byte minimum."""
+    f = b"\xff\xff\xff\xff\xff\xff\x00\x11\x22\x33\x44\x55" + struct.pack("!H", etype) + payload
+    if len(f) < 60:
+        f += b"\x00" * (60 - len(f))
+    return f
+
+
+def drain(s, n=4, timeout=0.4):
+    s.settimeout(timeout)
+    for _ in range(n):
+        try:
+            s.recvfrom(4096)
+        except socket.timeout:
+            break
+
+
+def recv_match(sock, want, timeout=2.0):
+    """Loop recvfrom until a datagram equals `want`, skipping stray traffic.
+
+    An UP veth gets kernel-generated IPv6 ND/MLD (~70-byte) frames that pcap/
+    AF_PACKET capture and the bridge dutifully relays — so the next packet at
+    the receiver isn't reliably ours. This scans until it sees `want` (matching
+    by content) or `timeout` elapses. Returns the matched bytes, else None."""
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        sock.settimeout(remaining)
+        try:
+            data, _ = sock.recvfrom(4096)
+        except socket.timeout:
+            return None
+        if data == want:
+            return data

--- a/tests/nio_raw/run_all.py
+++ b/tests/nio_raw/run_all.py
@@ -1,0 +1,29 @@
+"""Run the whole nio_raw test suite in sequence, exit non-zero if any fail."""
+import importlib
+import sys
+
+SUITES = [
+    "test_ethernet",
+    "test_linux_raw",
+]
+
+
+def main():
+    overall = 0
+    for name in SUITES:
+        print("\n" + "=" * 60)
+        print(name)
+        print("=" * 60)
+        mod = importlib.import_module(name)
+        rc = mod.main()
+        if rc != 0:
+            overall = rc
+    print("\n" + "=" * 60)
+    print("ALL SUITES: " + ("PASS" if overall == 0 else "FAIL"))
+    print("=" * 60)
+    return overall
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, __file__[: -len("run_all.py")])
+    raise SystemExit(main())

--- a/tests/nio_raw/test_ethernet.py
+++ b/tests/nio_raw/test_ethernet.py
@@ -1,0 +1,80 @@
+"""Regression for the `nio_ethernet` backend (libpcap L2 attach).
+
+Bridges a veth end (vnio0, via nio_ethernet) to a UDP NIO and checks raw L2
+frames round-trip intact in both directions, plus the command error paths.
+Run under sudo (or `unshare -Urn`) — pcap promisc + veth need CAP_NET_ADMIN.
+
+Topology (bridge "nre", 2 NIOs):
+  nio_ethernet vnio0  <-->  nio_udp lp<-->rp
+
+  veth->NIO:  raw(vnio1).send(frame) -> vnio0 -> bridge -> UDP -> bound rp
+  NIO->veth:  bound rp.sendto(frame, lp) -> bridge -> pcap_sendpacket vnio0 -> vnio1
+"""
+import socket
+import time
+
+from helpers import (Ubridge, Results, HOST, ubridge_binary, veth_up, veth_del,
+                     raw_sock, eth_frame, free_udp_port, drain, recv_match)
+
+PORT = 13180
+
+
+def main():
+    r = Results()
+    veth_up("vnio0", "vnio1")
+    try:
+        with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+            c = ub.connect()
+            try:
+                lp, rp = free_udp_port(), free_udp_port()
+                assert c.code("bridge create nre") == "100"
+                assert c.code("bridge add_nio_ethernet nre vnio0") == "100"
+                assert c.code("bridge add_nio_udp nre %d %s %d" % (lp, HOST, rp)) == "100"
+                assert c.code("bridge start nre") == "100"
+                time.sleep(0.3)
+
+                frame = eth_frame()
+
+                # ---- veth -> NIO: inject on vnio1, observe at UDP rp ----
+                raw = raw_sock("vnio1")
+                rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                rx.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                rx.bind((HOST, rp)); rx.settimeout(2.0)
+                raw.send(frame); drain(rx)          # prime
+                raw.send(frame)
+                got = recv_match(rx, frame)
+                r.check("veth->NIO relay intact", got == frame,
+                        "len %d vs %d" % (len(got) if got else 0, len(frame)))
+                raw.close(); rx.close()
+
+                # ---- NIO -> veth: inject UDP (src rp -> lp), sniff vnio1 ----
+                tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                tx.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                tx.bind((HOST, rp))
+                raw = raw_sock("vnio1")
+                tx.sendto(frame, (HOST, lp)); drain(raw)   # prime
+                tx.sendto(frame, (HOST, lp))
+                got = recv_match(raw, frame)
+                r.check("NIO->veth relay intact", got == frame,
+                        "len %d vs %d" % (len(got) if got else 0, len(frame)))
+                tx.close(); raw.close()
+
+                c.send("bridge stop nre"); c.send("bridge delete nre")
+
+                # ---- error paths ----
+                assert c.code("bridge create nre_e") == "100"
+                r.check("ethernet missing bridge -> 214",
+                        c.code("bridge add_nio_ethernet nope vnio0") == "214")
+                r.check("ethernet bad iface -> 206",
+                        c.code("bridge add_nio_ethernet nre_e dev_does_not_exist") == "206")
+                assert c.code("bridge delete nre_e") == "100"
+            finally:
+                c.close()
+    finally:
+        veth_del("vnio0")
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/nio_raw/test_linux_raw.py
+++ b/tests/nio_raw/test_linux_raw.py
@@ -1,0 +1,105 @@
+"""Regression for the `nio_linux_raw` backend (AF_PACKET SOCK_RAW L2 attach).
+
+Same veth-pair topology as test_ethernet but via nio_linux_raw: raw L2 frames
+round-trip intact both ways, plus the two command error paths nio_linux_raw
+uniquely has (bad iface, and device name > NIO_DEV_MAXLEN=64 -> 206).
+
+NOTE on VLAN: nio_linux_raw reconstructs an offloaded VLAN tag from
+PACKET_AUXDATA (tp_vlan_tci). That path only fires when the NIC hardware-
+offloads VLAN stripping; veth does not, so it can't be exercised here and is
+left as a documented gap. We send a plain tagged frame only to confirm the
+recvmsg+auxdata path passes non-offloaded frames through uncorrupted.
+
+Run under sudo (or `unshare -Urn`) — AF_PACKET + veth + promisc need caps.
+"""
+import socket
+import struct
+import time
+
+from helpers import (Ubridge, Results, HOST, ubridge_binary, veth_up, veth_del,
+                     raw_sock, eth_frame, free_udp_port, drain, recv_match)
+
+PORT = 13181
+
+# device name >= NIO_DEV_MAXLEN(64) is rejected by create_nio_linux_raw
+LONG_NAME = "x" * 64
+
+
+def main():
+    r = Results()
+    veth_up("vnio1a", "vnio1b")
+    try:
+        with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+            c = ub.connect()
+            try:
+                lp, rp = free_udp_port(), free_udp_port()
+                assert c.code("bridge create nrl") == "100"
+                assert c.code("bridge add_nio_linux_raw nrl vnio1a") == "100"
+                assert c.code("bridge add_nio_udp nrl %d %s %d" % (lp, HOST, rp)) == "100"
+                assert c.code("bridge start nrl") == "100"
+                time.sleep(0.3)
+
+                frame = eth_frame()
+
+                # ---- veth -> NIO ----
+                raw = raw_sock("vnio1b")
+                rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                rx.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                rx.bind((HOST, rp)); rx.settimeout(2.0)
+                raw.send(frame); drain(rx)
+                raw.send(frame)
+                got = recv_match(rx, frame)
+                r.check("raw veth->NIO relay intact", got == frame,
+                        "len %d vs %d" % (len(got) if got else 0, len(frame)))
+                raw.close(); rx.close()
+
+                # ---- NIO -> veth ----
+                tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                tx.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                tx.bind((HOST, rp))
+                raw = raw_sock("vnio1b")
+                tx.sendto(frame, (HOST, lp)); drain(raw)
+                tx.sendto(frame, (HOST, lp))
+                got = recv_match(raw, frame)
+                r.check("raw NIO->veth relay intact", got == frame,
+                        "len %d vs %d" % (len(got) if got else 0, len(frame)))
+                tx.close(); raw.close()
+
+                # ---- tagged frame passes through uncorrupted ----
+                # (veth doesn't HW-offload VLAN, so this is the passthrough path,
+                #  not the auxdata-reconstruction path.)
+                tagged = (b"\xff\xff\xff\xff\xff\xff\x00\x11\x22\x33\x44\x55"
+                          + struct.pack("!HHH", 0x8100, 0x0064, 0x0800) + b"VL")
+                tagged += b"\x00" * (60 - len(tagged))
+                raw = raw_sock("vnio1b")
+                rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                rx.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                rx.bind((HOST, rp)); rx.settimeout(2.0)
+                raw.send(tagged); drain(rx)
+                raw.send(tagged)
+                got = recv_match(rx, tagged)
+                r.check("tagged frame passthrough intact", got == tagged,
+                        "len %d vs %d" % (len(got) if got else 0, len(tagged)))
+                raw.close(); rx.close()
+
+                c.send("bridge stop nrl"); c.send("bridge delete nrl")
+
+                # ---- error paths ----
+                assert c.code("bridge create nrl_e") == "100"
+                r.check("raw missing bridge -> 214",
+                        c.code("bridge add_nio_linux_raw nope vnio1a") == "214")
+                r.check("raw bad iface -> 206",
+                        c.code("bridge add_nio_linux_raw nrl_e dev_does_not_exist") == "206")
+                r.check("raw name too long -> 206",
+                        c.code("bridge add_nio_linux_raw nrl_e %s" % LONG_NAME) == "206")
+                assert c.code("bridge delete nrl_e") == "100"
+            finally:
+                c.close()
+    finally:
+        veth_del("vnio1a")
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/packet_filter/README.md
+++ b/tests/packet_filter/README.md
@@ -1,0 +1,46 @@
+# packet_filter test suite
+
+Black-box regression for the three impairment packet filters that were
+previously only exercised in passing (delay had its own suite; `corrupt`,
+`frequency_drop` and `packet_loss` had no direct coverage). Each drives
+ubridge's hypervisor protocol over a 2-NIO UDP bridge and counts / inspects
+what exits the peer NIO.
+
+## Prerequisites
+
+Just the in-repo binary (these filters are pure user-space):
+
+```bash
+make            # builds ./ubridge
+```
+
+No `sudo make install`, no CAP_NET_ADMIN.
+
+## Running
+
+```bash
+cd tests/packet_filter
+
+# one suite
+python3 test_frequency_drop.py
+
+# everything
+python3 run_all.py
+```
+
+`run_all.py` exits non-zero if any suite fails, so it can gate CI.
+
+## Suites
+
+| Suite | What it covers |
+|-------|----------------|
+| `test_frequency_drop.py` | Deterministic 1-in-N drop: N>0 drops every Nth, N=0 passes all, N=-1 blackholes, identical runs are bit-for-bit repeatable, missing-value rejected (206). |
+| `test_packet_loss.py` | Random %-based drop: 100% drops all, 50% ~halves (statistical band), 0% passes ~all (documents the `<=` off-by-one), monotonic in percentage, out-of-range rejected (206). |
+| `test_corrupt.py` | Random %-based bit damage: at 100% every frame arrives changed with leading/trailing bytes intact and the middle slice XORed, corrupt never drops at any %, out-of-range rejected (206). |
+
+## Conventions
+
+- Re-uses the delay suite's `build_bridge` / `send_burst` / `recv_count` /
+  `bound_udp` via `helpers.py` (loaded by file path, no shared package).
+- Topology and the connected-NIO injection model are the same as the delay
+  suite — see `tests/delay/test_latency.py` for the diagram.

--- a/tests/packet_filter/helpers.py
+++ b/tests/packet_filter/helpers.py
@@ -1,0 +1,28 @@
+"""Shared helpers for the packet_filter test suite.
+
+Re-uses the delay suite's UDP traffic primitives (build_bridge / send_burst /
+recv_count / bound_udp) and the brctl Ubridge/Client/Results harness by file
+path, the same way delay/helpers.py loads brctl/common.py — so the test trees
+stay independent with no shared package.
+
+The filters under test (corrupt / packet_loss / frequency_drop) are pure
+user-space impairments applied on the bridge relay path. No CAP_NET_ADMIN
+needed; runs against the in-repo ./ubridge (the installed binary may be stale).
+"""
+import importlib.util
+import os
+
+_delay_helpers = os.path.join(os.path.dirname(__file__), "..", "delay", "helpers.py")
+_spec = importlib.util.spec_from_file_location("pf_delay_helpers", _delay_helpers)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+HOST = _mod.HOST
+Ubridge = _mod.Ubridge
+Client = _mod.Client
+Results = _mod.Results
+ubridge_binary = _mod.ubridge_binary
+bound_udp = _mod.bound_udp
+send_burst = _mod.send_burst
+recv_count = _mod.recv_count
+build_bridge = _mod.build_bridge

--- a/tests/packet_filter/run_all.py
+++ b/tests/packet_filter/run_all.py
@@ -1,0 +1,30 @@
+"""Run the whole packet_filter test suite in sequence, exit non-zero if any fail."""
+import importlib
+import sys
+
+SUITES = [
+    "test_frequency_drop",
+    "test_packet_loss",
+    "test_corrupt",
+]
+
+
+def main():
+    overall = 0
+    for name in SUITES:
+        print("\n" + "=" * 60)
+        print(name)
+        print("=" * 60)
+        mod = importlib.import_module(name)
+        rc = mod.main()
+        if rc != 0:
+            overall = rc
+    print("\n" + "=" * 60)
+    print("ALL SUITES: " + ("PASS" if overall == 0 else "FAIL"))
+    print("=" * 60)
+    return overall
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, __file__[: -len("run_all.py")])
+    raise SystemExit(main())

--- a/tests/packet_filter/test_corrupt.py
+++ b/tests/packet_filter/test_corrupt.py
@@ -1,0 +1,90 @@
+"""Regression for the `corrupt` packet filter (random %-based bit damage).
+
+When `random() % 100 <= percentage`, corrupt XORs a middle slice of the packet
+against a cycling 8-byte pattern:
+
+    length = len / 4
+    offset = len/2 - length/2 + 1        # bytes [offset, offset+length)
+
+Crucially the packet is still FORWARDED — corrupt never drops, it only damages
+bytes. Same <= off-by-one as packet_loss (0 still hits ~1%). Bounds 0..100 are
+validated; out-of-range -> 206.
+
+At 100% every packet is damaged, so the content checks are deterministic: the
+frame arrives, differs from what was sent, the leading bytes (outside the
+damage slice) are intact, and the delivered count equals the sent count. Pure
+user-space; no CAP_NET_ADMIN, no sudo.
+"""
+import socket
+import struct
+
+from helpers import (Ubridge, Results, HOST, ubridge_binary,
+                     bound_udp, send_burst, recv_count, build_bridge)
+
+PORT = 13192
+
+# 4B seq + 40B of 0xAA -> L = 44. corrupt slice: length = 11, offset = 18,
+# i.e. bytes [18, 29). So [0,18) and [29,44) must come through untouched.
+PAYLOAD = b"\xaa" * 40
+
+
+def _delivered(c, name, base, spec, n, timeout=3.0):
+    l1, r1, l2, r2 = build_bridge(c, name, base, filters=[spec])
+    tx, rx = bound_udp(r1), bound_udp(r2)
+    send_burst(tx, (HOST, l1), n)
+    got = recv_count(rx, n, timeout=timeout)[0]
+    tx.close()
+    rx.close()
+    return got
+
+
+def main():
+    r = Results()
+    with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        try:
+            # ---- 100%: one packet, detailed content check ----
+            l1, r1, l2, r2 = build_bridge(c, "co100", 13400, filters=["corrupt 100"])
+            tx, rx = bound_udp(r1), bound_udp(r2)
+            sent = struct.pack("!I", 0) + PAYLOAD
+            tx.sendto(sent, (HOST, l1))
+            rx.settimeout(3.0)
+            try:
+                got, _ = rx.recvfrom(2048)
+                arrived = True
+            except socket.timeout:
+                got, arrived = b"", False
+            r.check("corrupt 100 still delivered", arrived, "timeout" if not arrived else "len=%d" % len(got))
+            if arrived:
+                ndiff = sum(a != b for a, b in zip(got, sent))
+                r.check("frame changed", got != sent, "%d/%d bytes differ" % (ndiff, len(sent)))
+                r.check("length unchanged", len(got) == len(sent), "%d vs %d" % (len(got), len(sent)))
+                first = next((i for i in range(min(len(got), len(sent))) if got[i] != sent[i]), -1)
+                r.check("leading bytes intact", got[:18] == sent[:18], "first diff@%d" % first)
+                r.check("damage slice changed", got[18:29] != sent[18:29],
+                        "%d/11 slice bytes differ" % sum(a != b for a, b in zip(got[18:29], sent[18:29])))
+                r.check("trailing bytes intact", got[29:] == sent[29:], "ok")
+            tx.close()
+            rx.close()
+
+            # ---- corrupt never drops, at any percentage ----
+            got = _delivered(c, "co100b", 13410, "corrupt 100", 10)
+            r.check("corrupt 100 delivers all (10/10)", got == 10, "%d/10" % got)
+            got = _delivered(c, "co50", 13420, "corrupt 50", 10)
+            r.check("corrupt 50 delivers all (10/10)", got == 10, "%d/10" % got)
+
+            # ---- error: out-of-range percentage -> 206 ----
+            assert c.code("bridge create coe") == "100"
+            r.check("corrupt 101 rejected (206)",
+                    c.code("bridge add_packet_filter coe f corrupt 101") == "206")
+            r.check("corrupt -1 rejected (206)",
+                    c.code("bridge add_packet_filter coe f2 corrupt -1") == "206")
+            assert c.code("bridge delete coe") == "100"
+        finally:
+            c.close()
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/packet_filter/test_frequency_drop.py
+++ b/tests/packet_filter/test_frequency_drop.py
@@ -1,0 +1,77 @@
+"""Regression for the `frequency_drop` packet filter (deterministic 1-in-N drop).
+
+frequency_drop N drops exactly every Nth packet (a counter increments per
+packet; on reaching N it resets and drops):
+
+  N > 0  : drop 1 of every N  (positions N, 2N, 3N, ...)
+  N == 0 : pass all           (sentinel for "off")
+  N == -1: drop all           (sentinel for "blackhole")
+
+It is fully deterministic (no RNG), so delivered counts are exact. We feed a
+2-NIO UDP bridge and count what exits the peer NIO. Pure user-space; no
+CAP_NET_ADMIN, no sudo.
+
+Topology (all 127.0.0.1), bridge B with two NIOs:
+  source_nio L1<->R1   dest_nio L2<->R2
+  bound-R1 socket --sendto L1--> bridge[filter] --> dest_nio --sendto R2 (rx)
+"""
+from helpers import (Ubridge, Results, HOST, ubridge_binary,
+                     bound_udp, send_burst, recv_count, build_bridge)
+
+PORT = 13190
+
+
+def _delivered(c, name, base, spec, n):
+    """Bridge with one filter, send n, return how many exit the peer NIO."""
+    l1, r1, l2, r2 = build_bridge(c, name, base, filters=[spec])
+    tx, rx = bound_udp(r1), bound_udp(r2)
+    send_burst(tx, (HOST, l1), n)
+    got = recv_count(rx, n, timeout=2.0)[0]
+    tx.close()
+    rx.close()
+    return got
+
+
+def main():
+    r = Results()
+    with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        try:
+            # N=3 on 9 pkts -> drop positions 3,6,9 -> exactly 6 delivered
+            got = _delivered(c, "fd3", 13200, "frequency_drop 3", 9)
+            r.check("freq 3 drops every 3rd (9->6)", got == 6, "%d/9" % got)
+
+            # N=1 -> drop every packet
+            got = _delivered(c, "fd1", 13210, "frequency_drop 1", 5)
+            r.check("freq 1 drops all (5->0)", got == 0, "%d/5" % got)
+
+            # N=0 -> pass all
+            got = _delivered(c, "fd0", 13220, "frequency_drop 0", 5)
+            r.check("freq 0 passes all (5->5)", got == 5, "%d/5" % got)
+
+            # N=-1 -> blackhole
+            got = _delivered(c, "fdb", 13230, "frequency_drop -1", 5)
+            r.check("freq -1 blackhole (5->0)", got == 0, "%d/5" % got)
+
+            # determinism: two identical runs deliver the same count
+            counts = [
+                _delivered(c, "fdd%d" % i, base, "frequency_drop 4", 12)
+                for i, base in enumerate((13240, 13250))
+            ]
+            r.check("deterministic (12->9 twice)", counts == [9, 9], str(counts))
+
+            # error: type present, value missing -> setup argc!=1 -> 206
+            # (needs an existing bridge; create one without starting it so no
+            #  traffic ever hits the half-initialised failed filter)
+            assert c.code("bridge create fde") == "100"
+            r.check("missing value rejected (206)",
+                    c.code("bridge add_packet_filter fde f frequency_drop") == "206")
+            assert c.code("bridge delete fde") == "100"
+        finally:
+            c.close()
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/packet_filter/test_packet_loss.py
+++ b/tests/packet_filter/test_packet_loss.py
@@ -1,0 +1,65 @@
+"""Regression for the `packet_loss` packet filter (random %-based drop).
+
+Drops a packet when `random() % 100 <= percentage`. NOTE the off-by-one: the
+comparison is <=, so percentage=0 still drops ~1% (value 0) and percentage=50
+drops ~51% of packets (values 0..50). Bounds are validated: percentage must be
+0..100, else setup returns -1 and the command replies 206.
+
+Because it is random, counts are statistical: we send many packets and assert
+the delivered count falls in a band that rules out "no loss" and "total loss"
+while tolerating RNG variance. Pure user-space; no CAP_NET_ADMIN, no sudo.
+"""
+from helpers import (Ubridge, Results, HOST, ubridge_binary,
+                     bound_udp, send_burst, recv_count, build_bridge)
+
+PORT = 13191
+
+
+def _delivered(c, name, base, spec, n, timeout=4.0):
+    l1, r1, l2, r2 = build_bridge(c, name, base, filters=[spec])
+    tx, rx = bound_udp(r1), bound_udp(r2)
+    send_burst(tx, (HOST, l1), n)
+    got = recv_count(rx, n, timeout=timeout)[0]
+    tx.close()
+    rx.close()
+    return got
+
+
+def main():
+    r = Results()
+    with Ubridge(port=PORT, binary=ubridge_binary()) as ub:
+        c = ub.connect()
+        try:
+            # 100% -> all dropped (random()%100 <= 100 always)
+            got = _delivered(c, "pl100", 13300, "packet_loss 100", 30)
+            r.check("loss 100 drops all (30->0)", got == 0, "%d/30" % got)
+
+            # 50% -> roughly half. 200 pkts, band [60,140] = 30%..70%: tight
+            # enough to catch "no loss"/"total loss", loose enough for RNG.
+            got = _delivered(c, "pl50", 13310, "packet_loss 50", 200)
+            r.check("loss 50 ~halves (200 in [60,140])", 60 <= got <= 140, "%d/200" % got)
+
+            # 0% -> the <=0 quirk drops ~1%, so almost all delivered
+            got = _delivered(c, "pl0", 13320, "packet_loss 0", 200)
+            r.check("loss 0 ~passes all (>=190 of 200)", got >= 190, "%d/200" % got)
+
+            # monotonic: higher loss -> fewer delivered (25% vs 75%)
+            g25 = _delivered(c, "pl25", 13330, "packet_loss 25", 200)
+            g75 = _delivered(c, "pl75", 13340, "packet_loss 75", 200)
+            r.check("loss monotonic (25%% delivers >= 75%%)", g25 > g75, "%d vs %d" % (g25, g75))
+
+            # error: out-of-range percentage -> 206 (bridge must exist)
+            assert c.code("bridge create ple") == "100"
+            r.check("loss 101 rejected (206)",
+                    c.code("bridge add_packet_filter ple f packet_loss 101") == "206")
+            r.check("loss -1 rejected (206)",
+                    c.code("bridge add_packet_filter ple f2 packet_loss -1") == "206")
+            assert c.code("bridge delete ple") == "100"
+        finally:
+            c.close()
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
Adds `.github/workflows/test-ubridge.yml` gating the `tests/` regression suites on PRs to master, plus four new black-box suites for previously-uncovered modules.

## The workflow

Two parallel jobs (both `ubuntu-latest`, real VM):
- **userspace** — marker, delay, packet_filter, iol. No caps; runs `./ubridge` after `make`.
- **kernel** — brctl, link, tap, tc, capture, nio_raw, docker. `CAP_NET_ADMIN` via `sudo make install` (file capabilities) + a `ubtest` dummy fixture. brctl/link run as the unprivileged runner user against the capped binary (brctl `test_no_privs` must not run as root); the rest under `sudo`.

Each `tests/<module>/run_all.py` exits non-zero on failure, so the scripts gate CI directly (no pytest dependency).

## New suites in this PR

| Suite | Cases | Module covered |
|-------|-------|----------------|
| `packet_filter` | 22 | corrupt / packet_loss / frequency_drop (documents the `random()%100 <= pct` off-by-one and the corrupt damage-slice offset) |
| `iol` | 29 | IOL bridge lifecycle + dataplane: payload fidelity, per-port routing by `pkt[DST_PORT]`, and the exact NIO->IOL header ubridge builds (no IOL image — fakes the instance over the netio unix socket) |
| `nio_raw` | 10 | nio_ethernet (pcap) + nio_linux_raw (AF_PACKET) on a veth pair; both relay directions + error paths |
| `docker` | 24 | create_veth / delete_veth / set_mac_addr / move_to_ns netlink plumbing (no docker daemon involved) |

~85 new cases. No source changes — tests only. All verified green on a fork CI run (userspace + kernel jobs).
