### PR TITLE
fix: IOL bridge pthread_cancel(0) crash on delete after stop

### DIFF
--- a/src/hypervisor_iol_bridge.c
+++ b/src/hypervisor_iol_bridge.c
@@ -784,11 +784,16 @@ static int create_iol_port_entry(hypervisor_conn_t *conn, iol_bridge_t *bridge, 
    /* channel number */
    iol_nio->header[IOL_CHANNEL] = 0;
 
-   /* stop any previous NIO thread */
+   /* stop any previous NIO thread. Guard the cancel on tid, not on
+    * destination_nio: after iol_bridge stop (or if the port was never
+    * started) the listener is joined and tid == 0, while destination_nio is
+    * retained so the port can be restarted — pthread_cancel(0) segfaults. */
    if (iol_nio->destination_nio != NULL) {
-      pthread_cancel(iol_nio->tid);
-      pthread_join(iol_nio->tid, NULL);
-      iol_nio->tid = 0;
+      if (iol_nio->tid != 0) {
+         pthread_cancel(iol_nio->tid);
+         pthread_join(iol_nio->tid, NULL);
+         iol_nio->tid = 0;
+      }
       /* NULL the delay-line pointers before destroy — see
        * cmd_delete_nio_udp for the rationale. */
       delay_line_t *old_nio = iol_nio->delay_line_nio;
@@ -873,11 +878,16 @@ static int cmd_delete_nio_udp(hypervisor_conn_t *conn, int argc, char *argv[])
       return (-1);
    }
 
-   /* stop any previous NIO thread */
+   /* stop any previous NIO thread. Guard the cancel on tid, not on
+    * destination_nio: after iol_bridge stop (or if the port was never
+    * started) the listener is joined and tid == 0, while destination_nio is
+    * retained so the port can be restarted — pthread_cancel(0) segfaults. */
    if (iol_nio->destination_nio != NULL) {
-      pthread_cancel(iol_nio->tid);
-      pthread_join(iol_nio->tid, NULL);
-      iol_nio->tid = 0;
+      if (iol_nio->tid != 0) {
+         pthread_cancel(iol_nio->tid);
+         pthread_join(iol_nio->tid, NULL);
+         iol_nio->tid = 0;
+      }
       /* NULL the delay-line pointers before destroy so the IOL bridge
        * listener (IOL -> NIO direction) sees NULL if it concurrently
        * accesses them through port_table, and delay_line_destroy(NULL)


### PR DESCRIPTION
## Problem

`iol_bridge delete_nio_udp` (and the re-add path in `create_iol_port_entry`) segfaults when the port's listener thread is not running — e.g. after `iol_bridge stop`, or for a port that was never started.

Both sites guard `pthread_cancel(iol_nio->tid)` with `destination_nio != NULL`. But `iol_bridge stop` joins the listener and zeroes `tid` while **retaining** `destination_nio` (so the port can be restarted), and a never-started port also has `tid == 0`. In both cases delete/re-add reaches `pthread_cancel(0)` → **SIGSEGV**.

## Evidence (coredump, deterministic)

Reproducible on every run, no traffic needed:

```
iol_bridge create b1 <id>
iol_bridge add_nio_udp b1 <id> 0 0 <lport> 127.0.0.1 <rport>
iol_bridge start b1
iol_bridge stop b1
iol_bridge delete_nio_udp b1 0 0     ← SIGSEGV
```

systemd-coredump:

```
Signal: 11 (SEGV)
Stack trace of thread <cmd>:
  #0 pthread_cancel            (libc.so.6)
  #1 cmd_delete_nio_udp        (hypervisor_iol_bridge.c)
  #2 hypervisor_exec_cmd
```

## Fix

Guard the cancel+join on `tid != 0` instead of `destination_nio != NULL`:

```c
if (iol_nio->destination_nio != NULL) {
    if (iol_nio->tid != 0) {
        pthread_cancel(iol_nio->tid);
        pthread_join(iol_nio->tid, NULL);
        iol_nio->tid = 0;
    }
    /* ... delay-line + nio teardown unchanged ... */
}
```

`cmd_delete_bridge` and `cmd_stop_bridge` are unaffected — both already gate teardown on `bridge->running`, so their `tid`s are valid when reached.

## Verification

The patched build survives the repro above plus: delete-without-start, repeated stop/start cycles, and double-delete. `tests/iol` and `tests/delay` suites pass.

> Note: orthogonal to #119 (delay-line race). Both touch the same teardown blocks but address separate issues — this one wraps the `pthread_cancel`; #119 wraps the delay-line destroy. They merge together cleanly.
