### PR TITLE
feat(marker): add linktype support to the mark filter

### DIFF
--- a/doc/gns3server-integration.md
+++ b/doc/gns3server-integration.md
@@ -217,24 +217,32 @@ suppresses / re-enables **all** signal emission while keeping the sink open
 
 **Per-link filter** — when the user configures BPF on a link:
 ```
-bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [link <id>] [dir <tx|rx>] [pcap <path>]
+bridge add_packet_filter <bridge> <name> mark <bpf_expr> [linktype <dlt>] [tag <id>] [link <id>] [dir <tx|rx>] [pcap <path>]
 ```
 - `<bridge>`: the ubridge bridge for this GNS3 link.
 - `<name>`: filter name (gns3server-chosen; echoed in signals, used as pcap identity).
 - `<bpf_expr>`: libpcap cBPF syntax (same as the `bpf` filter type).
+- `linktype <dlt>`: optional data-link type for the BPF compile **and** the pcap
+  header; defaults to `EN10MB`. **Pass it for serial links** (Frame Relay / PPP
+  / HDLC), whose header layout differs from Ethernet — otherwise the BPF matches
+  at wrong offsets and Wireshark mis-parses the pcap. gns3server should derive it
+  from the GNS3 link's data-link type — `HDLC`→`C_HDLC`, `PPP`→`PPP`, `Frame
+  Relay`→`FRELAY`, ATM→`ATM_RFC1483`; Ethernet links omit it. See
+  [`marker.md`](marker.md) for the accepted names and the DLT/LINKTYPE caveat.
 - `tag <id>`: optional correlation id echoed in the signal.
 - `link <id>`: optional link id echoed in the signal, for per-link attribution.
   Needed when one ubridge bridge serves several GNS3 links (e.g. IOU's per-node
   bridge): there `bridge` and `filter` are identical across links, so `link` is
   the only way to tell signals — and pcap files — apart.
 - `pcap <path>`: optional; if given, every matched packet is appended to that
-  pcap (standard, `EN10MB`). **gns3server should name it to encode identity**,
+  pcap (standard pcap; header linktype follows `linktype`, default `EN10MB`).
+  **gns3server should name it to encode identity**,
   keyed on `link` (not `bridge`+`filter`, which collide when one bridge serves
   several links), e.g. `<project>/markers/<node_id>_<link>_<filter>.pcap`.
 - `dir <tx|rx>`: optional direction filter. `tx` = only signal/capture on
   device-side ingress (capture node sending); `rx` = only on link-side ingress
   (receiving). Omit = both directions. Echoed in the signal as `dir=`.
-- `tag`/`link`/`dir`/`pcap` keyword pairs may appear in any order; each is normally
+- `linktype`/`tag`/`link`/`dir`/`pcap` keyword pairs may appear in any order; each is normally
   given once (a repeat silently overwrites the earlier value — last one wins).
 
 **Disable / change** — `bridge delete_packet_filter <bridge> <name>` (closes and
@@ -282,7 +290,7 @@ kv = dict(t.split(b"=",1) for t in data.split() if b"=" in t)
 
 ### 3.4 What gns3server reads (replay)
 
-Each `pcap <path>` is a **standard pcap (`EN10MB`)** containing that filter's
+Each `pcap <path>` is a **standard pcap** (header linktype = the filter's `linktype`, default `EN10MB`) containing that filter's
 matched packets in match order, each timestamped. Read with tcpdump / tshark /
 Wireshark / PyShark natively. **The link identity is the file path** (pcap records
 carry no per-packet metadata) — gns3server tracks `path ↔ (node, link, filter)`.
@@ -363,7 +371,7 @@ capture start_kernel <if> <pcap> [dlt]                               capture sto
 marker sink <host> <port>          marker node <id>                  marker off                     marker status
 marker pause                      marker resume
 # mark filter (under bridge)
-bridge add_packet_filter <br> <name> mark <bpf> [tag <id>] [link <id>] [dir <tx|rx>] [pcap <path>]
+bridge add_packet_filter <br> <name> mark <bpf> [linktype <dlt>] [tag <id>] [link <id>] [dir <tx|rx>] [pcap <path>]
 bridge delete_packet_filter <br> <name>
 bridge enable_packet_filter <br> <name> on|off          # pause/resume one filter (any type)
 ```

--- a/doc/gns3server-integration.md
+++ b/doc/gns3server-integration.md
@@ -225,10 +225,12 @@ bridge add_packet_filter <bridge> <name> mark <bpf_expr> [linktype <dlt>] [tag <
 - `linktype <dlt>`: optional data-link type for the BPF compile **and** the pcap
   header; defaults to `EN10MB`. **Pass it for serial links** (Frame Relay / PPP
   / HDLC), whose header layout differs from Ethernet — otherwise the BPF matches
-  at wrong offsets and Wireshark mis-parses the pcap. gns3server should derive it
-  from the GNS3 link's data-link type — `HDLC`→`C_HDLC`, `PPP`→`PPP`, `Frame
-  Relay`→`FRELAY`, ATM→`ATM_RFC1483`; Ethernet links omit it. See
-  [`marker.md`](marker.md) for the accepted names and the DLT/LINKTYPE caveat.
+  at wrong offsets and Wireshark mis-parses the pcap. gns3server should pass the
+  serial port's `data_link_types` value with the `DLT_` prefix stripped — they
+  are exactly what ubridge accepts: Cisco HDLC→`C_HDLC`, Cisco PPP→`PPP_SERIAL`
+  (DLT 50, HDLC-framed — **not** `PPP`/DLT 9, which is raw/unframed), Frame
+  Relay→`FRELAY`; Ethernet links omit it. See [`marker.md`](marker.md) for the
+  accepted names and the DLT/LINKTYPE caveat.
 - `tag <id>`: optional correlation id echoed in the signal.
 - `link <id>`: optional link id echoed in the signal, for per-link attribution.
   Needed when one ubridge bridge serves several GNS3 links (e.g. IOU's per-node

--- a/doc/marker.md
+++ b/doc/marker.md
@@ -27,7 +27,7 @@ no-op when no sink is set, so `mark` filters are cheap when unused.
 Registered under the `bridge` module like the other filter types:
 
 ```
-bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [link <id>] [dir <tx|rx>] [pcap <path>]
+bridge add_packet_filter <bridge> <name> mark <bpf_expr> [linktype <dlt>] [tag <id>] [link <id>] [dir <tx|rx>] [pcap <path>]
 ```
 
 - Matches via libpcap cBPF (`pcap_offline_filter`), exactly like the `bpf`
@@ -46,15 +46,26 @@ bridge add_packet_filter <bridge> <name> mark <bpf_expr> [tag <id>] [link <id>] 
   pcap on device-side ingress (capture node sending); `rx` = only on link-side
   ingress (capture node receiving). When omitted (default) the filter fires on
   both directions — backward compatible.
-- `pcap <path>` is an optional path to a pcap file (standard, `EN10MB`) that
+- `pcap <path>` is an optional path to a pcap file (standard pcap) that
   **accumulates every matched packet** for this filter (open once on setup,
   append one record per match, closed when the filter is deleted). This is a
-  BPF-filtered capture: only matches land in the file. gns3server names the
+  BPF-filtered capture: only matches land in the file. The file header's
+  data-link type follows `linktype` (default `EN10MB`). gns3server names the
   path per link (e.g. `<project>/markers/<node>_<link>_<filter>.pcap`), keyed
   on `link` — `bridge`+`filter` collide when one bridge serves several links
   (IOU) — and reads it back for offline replay/analysis with
   tcpdump/Wireshark/PyShark.
-- Keyword pairs (`tag`, `link`, `dir`, `pcap`) may appear in any order.
+- `linktype <dlt>` sets the **data-link type** the BPF is compiled against and
+  written into the pcap header (when `pcap` is given). Defaults to `EN10MB`
+  (Ethernet). **Required for serial links**: Frame Relay / PPP / HDLC frames
+  have a different header layout, so an Ethernet-compiled BPF matches at the
+  wrong offsets and the pcap is mis-parsed by Wireshark (garbled protocols).
+  Value is any name `pcap_datalink_name_to_val(3)` accepts; common ones:
+  `C_HDLC` (Cisco HDLC), `PPP`, `FRELAY` (Frame Relay), `ATM_RFC1483`. An
+  unknown name falls back to `EN10MB` with a warning. Mirrors the `bpf` filter
+  type's link-layer argument.
+- Keyword pairs (`linktype`, `tag`, `link`, `dir`, `pcap`) may appear in any
+  order.
 
 ```
 bridge add_packet_filter br0 dhcp_probe mark "udp port 67" tag 11
@@ -66,6 +77,9 @@ bridge add_packet_filter br0 icmp_l3 mark "icmp" link 3 pcap /tmp/icmp_l3.pcap
 
 # all at once (real-time signal + per-link + on-disk capture):
 bridge add_packet_filter br0 dhcp mark "udp port 67" tag 11 link 3 pcap /tmp/dhcp.pcap
+
+# serial link (Cisco HDLC): linktype fixes BPF offsets + the pcap header
+bridge add_packet_filter br0 s0 mark "ip" linktype C_HDLC link 3 pcap /tmp/s0.pcap
 ```
 
 > The `pcap` option writes a **standard pcap** (same writer as
@@ -188,10 +202,13 @@ while True:
 
 ## Testing
 
-`tests/marker/` stands up a UDP listener as the sink, injects an IP frame into
-a UDP-NIO bridge with a `mark "ip" tag 7` filter, and asserts the signal arrives
-with the right node/filter/tag/len, that the frame was still relayed (passive),
-and that `marker off` stops the signals.
+`tests/marker/` stands up a UDP listener as the sink, injects frames into a
+UDP-NIO bridge and asserts: the signal arrives with the right node/filter/tag/
+len, the frame was still relayed (passive), `marker off` stops signals,
+direction filtering, pause/resume, and — in `test_linktype.py` — that `linktype`
+actually shifts BPF offsets (a Cisco-HDLC frame matches `ip` only under
+`linktype C_HDLC`, not the default `EN10MB`) and writes the right DLT into the
+pcap header.
 
 > Note: ubridge's UDP NIO `connect()`s to the configured remote, so it only
 > accepts packets whose source is that remote — the test binds the injector to
@@ -200,5 +217,5 @@ and that `marker off` stops the signals.
 **Pure user-space (UDP + libpcap cBPF) — no `CAP_NET_ADMIN` needed, no sudo:**
 
 ```bash
-cd tests/marker && python3 run_all.py   # 13/13 PASS
+cd tests/marker && python3 run_all.py   # 61/61 PASS
 ```

--- a/doc/marker.md
+++ b/doc/marker.md
@@ -60,10 +60,11 @@ bridge add_packet_filter <bridge> <name> mark <bpf_expr> [linktype <dlt>] [tag <
   (Ethernet). **Required for serial links**: Frame Relay / PPP / HDLC frames
   have a different header layout, so an Ethernet-compiled BPF matches at the
   wrong offsets and the pcap is mis-parsed by Wireshark (garbled protocols).
-  Value is any name `pcap_datalink_name_to_val(3)` accepts; common ones:
-  `C_HDLC` (Cisco HDLC), `PPP`, `FRELAY` (Frame Relay), `ATM_RFC1483`. An
-  unknown name falls back to `EN10MB` with a warning. Mirrors the `bpf` filter
-  type's link-layer argument.
+  Value is any name `pcap_datalink_name_to_val(3)` accepts; common serial ones:
+  `C_HDLC` (Cisco HDLC), `PPP_SERIAL` (Cisco PPP — HDLC-framed, DLT 50; **not**
+  `PPP`, which is raw/unframed, DLT 9), `FRELAY` (Frame Relay), `ATM_RFC1483`.
+  An unknown name falls back to `EN10MB` with a warning. Mirrors the `bpf`
+  filter type's link-layer argument.
 - Keyword pairs (`linktype`, `tag`, `link`, `dir`, `pcap`) may appear in any
   order.
 

--- a/src/packet_filter.c
+++ b/src/packet_filter.c
@@ -416,12 +416,17 @@ struct mark_data {
 };
 
 /* Setup: argv[0] = bpf expr; optional keyword pairs "tag <id>" / "link <id>" /
- * "pcap <path>" / "dir <tx|rx>" (any order, each at most once). */
+ * "pcap <path>" / "dir <tx|rx>" / "linktype <dlt-name>" (any order, each at
+ * most once). linktype defaults to EN10MB and is applied to both the BPF
+ * compile (so field offsets match the link layer) and the pcap file header;
+ * see pcap_datalink_name_to_val(3) for accepted names (e.g. C_HDLC, PPP,
+ * FRELAY, ATM_RFC1483). */
 static int mark_setup(void **opt, int argc, char *argv[])
 {
    struct mark_data *data = *opt;
    pcap_t *pcap_dev;
    char *filter;
+   const char *linktype_str = "EN10MB";   /* default link layer for offsets + pcap header */
    int link_type, i;
 
    if (argc < 1)
@@ -435,7 +440,23 @@ static int mark_setup(void **opt, int argc, char *argv[])
    }
 
    filter = argv[0];
-   link_type = DLT_EN10MB;
+
+   /* First pass: pick up an optional "linktype <name>" pair before compiling,
+    * since the DLT fixes the BPF field offsets (14-byte Ethernet header vs
+    * 4-byte HDLC/PPP etc.). The pair may sit anywhere among the keyword/value
+    * arguments, so scan for it explicitly first. */
+   for (i = 1; i + 1 < argc; i += 2) {
+      if (!strcmp(argv[i], "linktype")) {
+         linktype_str = argv[i + 1];
+         break;   /* each keyword at most once; first occurrence wins */
+      }
+   }
+   if ((link_type = pcap_datalink_name_to_val(linktype_str)) == -1) {
+      fprintf(stderr, "mark: unknown linktype '%s', assuming Ethernet.\n", linktype_str);
+      link_type = DLT_EN10MB;
+      linktype_str = "EN10MB";
+   }
+
    pcap_dev = pcap_open_dead(link_type, 65535);
    if (pcap_compile(pcap_dev, &data->fp, filter, 1, PCAP_NETMASK_UNKNOWN) < 0) {
        fprintf(stderr, "Cannot compile mark filter '%s': %s\n", filter, pcap_geterr(pcap_dev));
@@ -444,9 +465,12 @@ static int mark_setup(void **opt, int argc, char *argv[])
    }
    pcap_close(pcap_dev);
 
-   /* optional keyword/value pairs: tag <id>, link <id>, pcap <path> */
+   /* optional keyword/value pairs: tag <id>, link <id>, pcap <path>, dir.
+    * "linktype <name>" was already consumed in the first pass above. */
    for (i = 1; i + 1 < argc; i += 2) {
-      if (!strcmp(argv[i], "tag")) {
+      if (!strcmp(argv[i], "linktype")) {
+         continue;   /* already applied to the BPF compile and pcap header */
+      } else if (!strcmp(argv[i], "tag")) {
          free(data->tag);
          data->tag = strdup(argv[i + 1]);
       } else if (!strcmp(argv[i], "link")) {
@@ -455,7 +479,7 @@ static int mark_setup(void **opt, int argc, char *argv[])
       } else if (!strcmp(argv[i], "pcap")) {
          if (data->cap)
             free_pcap_capture(data->cap);
-         data->cap = create_pcap_capture(argv[i + 1], "EN10MB");
+         data->cap = create_pcap_capture(argv[i + 1], linktype_str);
          if (!data->cap) {
             fprintf(stderr, "mark: cannot open pcap '%s'\n", argv[i + 1]);
             return (-1);

--- a/tests/marker/run_all.py
+++ b/tests/marker/run_all.py
@@ -5,6 +5,7 @@ import sys
 SUITES = [
     "test_basic",
     "test_dir_filter",
+    "test_linktype",
     "test_pause",
     "test_reset_preserves_mark",
 ]

--- a/tests/marker/test_linktype.py
+++ b/tests/marker/test_linktype.py
@@ -29,7 +29,6 @@ REPO_UBRIDGE = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__f
 # stores LINKTYPE, which equals the DLT for these layers — except ATM_RFC1483,
 # which is DLT 11 but LINKTYPE 100 in the file (libpcap maps it on write).
 DLT_EN10MB = 1
-DLT_PPP = 9
 DLT_CHDLC = 104
 DLT_FRELAY = 107
 
@@ -129,7 +128,7 @@ def main():
                 c.send("bridge start br0")
 
                 # --- A. accepted linktype names ---------------------------------
-                for lt in ("C_HDLC", "PPP", "FRELAY", "ATM_RFC1483"):
+                for lt in ("C_HDLC", "PPP_SERIAL", "FRELAY", "ATM_RFC1483"):
                     r.check("accept linktype %s" % lt,
                             add_mark("fa", "ip", "linktype", lt).startswith("100-"))
                     c.send("bridge delete_packet_filter br0 fa")
@@ -158,9 +157,9 @@ def main():
                 # create_pcap_capture() writes the header at add time; deleting the
                 # filter flushes it. Header is written even with no matched packet.
                 # pcap stores LINKTYPE (== DLT except ATM_RFC1483: DLT 11 / LINK 100).
-                file_linktype = {"C_HDLC": DLT_CHDLC, "PPP": DLT_PPP, "FRELAY": DLT_FRELAY,
+                file_linktype = {"C_HDLC": DLT_CHDLC, "PPP_SERIAL": 50, "FRELAY": DLT_FRELAY,
                                  "ATM_RFC1483": 100, "EN10MB": DLT_EN10MB}
-                for lt in ("C_HDLC", "PPP", "FRELAY", "ATM_RFC1483", "EN10MB"):
+                for lt in ("C_HDLC", "PPP_SERIAL", "FRELAY", "ATM_RFC1483", "EN10MB"):
                     PCAP = "/tmp/ubmark_linktype.pcap"
                     if os.path.exists(PCAP):
                         os.remove(PCAP)

--- a/tests/marker/test_linktype.py
+++ b/tests/marker/test_linktype.py
@@ -1,0 +1,193 @@
+"""linktype support for the `mark` packet filter.
+
+The mark filter compiles its BPF against a link-layer DLT (default EN10MB).
+`linktype <name>` overrides it, fixing both the BPF field offsets and the pcap
+file header. This verifies:
+
+  * accepted names: C_HDLC / PPP / FRELAY / ATM_RFC1483
+  * linktype actually changes BPF offsets — a Cisco-HDLC frame matches `ip`
+    only when compiled under DLT_C_HDLC, not under the default EN10MB
+  * the default (EN10MB) still matches an Ethernet frame (no regression)
+  * an unknown name falls back to EN10MB (filter still installs)
+  * the chosen DLT is written into the pcap global header
+
+Pure user-space (UDP NIO + libpcap cBPF) — no CAP_NET_ADMIN, no sudo.
+"""
+import os
+import sys
+import socket
+import struct
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "brctl"))
+from common import Ubridge, Results  # noqa: E402
+
+PORT = 13070
+REPO_UBRIDGE = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "ubridge"))
+
+# DLT values (the programming values passed to pcap_open_dead). The pcap *file*
+# stores LINKTYPE, which equals the DLT for these layers — except ATM_RFC1483,
+# which is DLT 11 but LINKTYPE 100 in the file (libpcap maps it on write).
+DLT_EN10MB = 1
+DLT_PPP = 9
+DLT_CHDLC = 104
+DLT_FRELAY = 107
+
+
+def _free_udp():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _ipv4():
+    """Minimal IPv4 header (20 bytes, no options, proto=UDP)."""
+    return struct.pack("!BBHHHBBH4s4s", 0x45, 0, 20, 0x1234, 0, 64, 17, 0,
+                       bytes([10, 0, 0, 1]), bytes([10, 0, 0, 2]))
+
+
+def _eth_ip_frame():
+    """Ethernet + IPv4 — matches BPF `ip` under DLT_EN10MB."""
+    eth = b"\xff\xff\xff\xff\xff\xff\x00\x11\x22\x33\x44\x55" + struct.pack("!H", 0x0800)
+    return eth + _ipv4()
+
+
+def _chdlc_ip_frame():
+    """Cisco-HDLC + IPv4 (Address 0x0F, Control 0x00, Type 0x0800).
+
+    Matches BPF `ip` under DLT_C_HDLC (proto at offset 2 == 0x0800), but NOT
+    under DLT_EN10MB (ether proto at offset 12 reads 0x4011, not 0x0800).
+    """
+    return b"\x0f\x00" + struct.pack("!H", 0x0800) + _ipv4()
+
+
+def _pcap_network(path):
+    """Read the link-layer type (network) field from a pcap global header."""
+    with open(path, "rb") as f:
+        gh = f.read(24)
+    if len(gh) < 24:
+        return None
+    magic = struct.unpack("<I", gh[:4])[0]
+    endian = "<" if magic == 0xA1B2C3D4 else ">"   # pcap is host-endian
+    return struct.unpack(endian + "I", gh[20:24])[0]
+
+
+def main():
+    r = Results()
+    marker_port = _free_udp()
+    la, lb = _free_udp(), _free_udp()      # NIO listen ports (ubridge binds these)
+    ra, rb = _free_udp(), _free_udp()      # NIO remote ports (listeners here)
+
+    ms = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); ms.settimeout(2.0); ms.bind(("127.0.0.1", marker_port))
+    rbs = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); rbs.settimeout(2.0); rbs.bind(("127.0.0.1", rb))
+    # nio_udp connect()s to the remote, so bind the injector to NIO-A's remote port.
+    inj = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    inj.bind(("127.0.0.1", ra))
+
+    eth_frame = _eth_ip_frame()
+    chdlc_frame = _chdlc_ip_frame()
+
+    def drain():
+        """Drop any stale marker signals before the next injection."""
+        ms.settimeout(0)
+        try:
+            while True:
+                ms.recvfrom(4096)
+        except (BlockingIOError, OSError):
+            pass
+        finally:
+            ms.settimeout(2.0)
+
+    def add_mark(name, expr, *kw):
+        cmd = "bridge add_packet_filter br0 %s mark %s" % (name, expr)
+        if kw:
+            cmd += " " + " ".join(kw)
+        return c.send(cmd)
+
+    def inject_expect(frame, expect_signal, label):
+        drain()
+        inj.sendto(frame, ("127.0.0.1", la))
+        time.sleep(0.3)
+        try:
+            ms.recvfrom(4096)
+            got = True
+        except socket.timeout:
+            got = False
+        r.check(label, got == expect_signal, "got=%s expect=%s" % (got, expect_signal))
+
+    try:
+        with Ubridge(port=PORT, binary=REPO_UBRIDGE) as ub:
+            c = ub.connect()
+            try:
+                c.send("marker sink 127.0.0.1 %d" % marker_port)
+                c.send("marker node lt-node")
+                c.send("bridge create br0")
+                c.send("bridge add_nio_udp br0 %d 127.0.0.1 %d" % (la, ra))   # NIO-A
+                c.send("bridge add_nio_udp br0 %d 127.0.0.1 %d" % (lb, rb))   # NIO-B
+                c.send("bridge start br0")
+
+                # --- A. accepted linktype names ---------------------------------
+                for lt in ("C_HDLC", "PPP", "FRELAY", "ATM_RFC1483"):
+                    r.check("accept linktype %s" % lt,
+                            add_mark("fa", "ip", "linktype", lt).startswith("100-"))
+                    c.send("bridge delete_packet_filter br0 fa")
+
+                # --- B. linktype changes BPF field offsets ----------------------
+                # C_HDLC frame + `ip` compiled under DLT_C_HDLC -> match
+                add_mark("fb", "ip", "linktype", "C_HDLC")
+                inject_expect(chdlc_frame, True, "C_HDLC frame matches under linktype C_HDLC")
+                c.send("bridge delete_packet_filter br0 fb")
+
+                # same frame + `ip` under default EN10MB -> no match (offset 12 != 0x0800)
+                add_mark("fc", "ip")
+                inject_expect(chdlc_frame, False, "C_HDLC frame does NOT match under default EN10MB")
+
+                # --- C. default still matches Ethernet (no regression) ----------
+                inject_expect(eth_frame, True, "Ethernet frame matches under default EN10MB")
+                c.send("bridge delete_packet_filter br0 fc")
+
+                # --- D. unknown linktype falls back to EN10MB -------------------
+                r.check("accept unknown linktype (fallback)",
+                        add_mark("fd", "ip", "linktype", "BOGUS").startswith("100-"))
+                inject_expect(eth_frame, True, "unknown linktype falls back to EN10MB (eth match)")
+                c.send("bridge delete_packet_filter br0 fd")
+
+                # --- E. chosen linktype written into the pcap global header -----
+                # create_pcap_capture() writes the header at add time; deleting the
+                # filter flushes it. Header is written even with no matched packet.
+                # pcap stores LINKTYPE (== DLT except ATM_RFC1483: DLT 11 / LINK 100).
+                file_linktype = {"C_HDLC": DLT_CHDLC, "PPP": DLT_PPP, "FRELAY": DLT_FRELAY,
+                                 "ATM_RFC1483": 100, "EN10MB": DLT_EN10MB}
+                for lt in ("C_HDLC", "PPP", "FRELAY", "ATM_RFC1483", "EN10MB"):
+                    PCAP = "/tmp/ubmark_linktype.pcap"
+                    if os.path.exists(PCAP):
+                        os.remove(PCAP)
+                    add_mark("fe", "ip", "linktype", lt, "pcap", PCAP)
+                    time.sleep(0.1)
+                    c.send("bridge delete_packet_filter br0 fe")   # close/flush the pcap
+                    time.sleep(0.1)
+                    net = _pcap_network(PCAP) if os.path.exists(PCAP) else None
+                    r.check("pcap linktype for %s" % lt,
+                            os.path.exists(PCAP) and net == file_linktype[lt],
+                            "network=%s expect=%d" % (net, file_linktype[lt]))
+                    if os.path.exists(PCAP):
+                        os.remove(PCAP)
+
+                # status sanity
+                st = c.send("marker status")
+                r.check("status reports emitted", "emitted=" in st, st.replace("\n", " | "))
+            finally:
+                c.send("bridge stop br0")
+                c.send("bridge delete br0")
+                c.close()
+    finally:
+        for s in (ms, rbs, inj):
+            s.close()
+
+    return 0 if r.summary() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a `linktype <dlt-name>` keyword to the `mark` packet filter, defaulting to `EN10MB`. The DLT is applied to **both** the BPF compile (so field offsets match the link layer) and the pcap file header (from the optional `pcap` sink). Closes the gap with the `bpf` filter type, which already took a linktype as its second positional arg.

## Why

For Ethernet the default `EN10MB` is correct, but **serial links need an explicit linktype**: Frame Relay / PPP / HDLC frames have a different header layout, so an Ethernet-compiled BPF matches at the wrong offsets and Wireshark mis-parses the captured pcap. gns3-server derives the value from the serial port's `data_link_types` with the `DLT_` prefix stripped.

## Changes

- **feat** `src/packet_filter.c` — `mark_setup` accepts `linktype <dlt>` (any name `pcap_datalink_name_to_val` accepts; unknown → fallback `EN10MB` + warning).
- **docs** `doc/marker.md`, `doc/gns3server-integration.md` — syntax, serial rationale, and a GNS3 data-link type → DLT mapping table (Cisco HDLC→`C_HDLC`, Cisco PPP→`PPP_SERIAL`, Frame Relay→`FRELAY`).
- **fix** — use `PPP_SERIAL` (DLT 50, HDLC-framed) for serial PPP, **not** `PPP` (DLT 9, raw/unframed), aligning with GNS3's `serial_port.py` as the single source of truth.

No code change was needed for `PPP_SERIAL` — the open `pcap_datalink_name_to_val` validation already accepts it.

## Tests

New `tests/marker/test_linktype.py` (15 checks): name acceptance, that linktype actually shifts BPF offsets (a Cisco-HDLC frame matches `ip` only under `linktype C_HDLC`, not the default `EN10MB`), default/fallback regression, and the pcap header DLT (incl. the `ATM_RFC1483` DLT 11 / LINKTYPE 100 caveat).

\`\`\`bash
cd tests/marker && python3 run_all.py   # 61/61 PASS
\`\`\`

Pure user-space (UDP NIO + libpcap cBPF) — no `CAP_NET_ADMIN`, no sudo.