### PR TITLE
fix(ubridge): set bridge->running to stop threads in cleanup & REFACTOR

### DIFF
--- a/.github/workflows/test-ubridge.yml
+++ b/.github/workflows/test-ubridge.yml
@@ -20,6 +20,20 @@ on:
       - master
 
 jobs:
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Install test dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcriterion-dev libpcap-dev pkg-config
+
+      - name: Test
+        run: make test
+
   # ---------------------------------------------------------------------
   # Userspace suites — the riskiest user-space logic and zero privilege
   # friction. Run right after `make`, against the in-repo ./ubridge.

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ ubridge.ini
 # Python
 __pycache__/
 *.pyc
+
+# lsp
+.clangd

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,15 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+BUILDDIR    = build
+NAME        = ubridge
+DEBUG_TARGET = $(BUILDDIR)/$(NAME)
+UNIT_TEST_TARGET = $(BUILDDIR)/unit_tests
+UNIT_TEST_SRC = $(wildcard tests/unit/*.c)
 
-NAME    =   ubridge
-
-SRC     =   src/ubridge.c               \
+SRC     =   src/main.c                  \
+            src/ubridge_options.c       \
+            src/ubridge.c               \
             src/nio.c                   \
             src/nio_udp.c               \
             src/nio_unix.c              \
@@ -37,15 +42,16 @@ SRC     =   src/ubridge.c               \
             src/hypervisor_bridge.c
 
 
-OBJ     =   $(SRC:.c=.o)
+OBJ       = $(SRC:.c=.o)
+DEBUG_OBJ = $(SRC:%.c=$(BUILDDIR)/%.o)
 
-CC      ?=   gcc
+CC      ?=  gcc
 
-CFLAGS  +=   -Wall
+CFLAGS  +=  -Wall
 
 BINDIR  =   /usr/local/bin
 
-LIBS =   -lpthread -lpcap -lm
+LIBS    =   -lpthread -lpcap -lm
 
 # Linux-only: RAW Ethernet + netlink-backed hypervisor modules
 SRC += src/nio_linux_raw.c             \
@@ -67,21 +73,43 @@ else
 	   src/iniparser/dictionary.c
 endif
 
-##############################
+# debug options
+SANITIZERS = address,undefined
+DEBUG_CFLAGS = -O1 -g -fsanitize=$(SANITIZERS) -fno-omit-frame-pointer
+DEBUG_LDFLAGS = -fsanitize=$(SANITIZERS)
 
-$(NAME)	: $(OBJ)
+##############################
+.PHONY: clean debug all install test
+
+$(BUILDDIR)/%.o: %.c
+	mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(DEBUG_CFLAGS) -c $< -o $@
+
+$(NAME): $(OBJ)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $(NAME) $(OBJ) $(LIBS)
 
-.PHONY: clean
+$(DEBUG_TARGET): $(DEBUG_OBJ)
+	$(CC) $(CFLAGS) $(DEBUG_CFLAGS) $(LDFLAGS) $(DEBUG_LDFLAGS) -o $(DEBUG_TARGET) $(DEBUG_OBJ) $(LIBS)
+
+all: $(NAME)
+
+debug: $(DEBUG_TARGET)
 
 clean:
 	-rm -f $(OBJ)
-	-rm -f *~
 	-rm -f $(NAME)
+	-rm -f *~
+	-rm -rf $(BUILDDIR)
 
-all	: $(NAME)
-
-install : $(NAME)
+install: $(NAME)
 	chmod +x $(NAME)
 	cp -p $(NAME) $(BINDIR)
 	setcap cap_net_admin,cap_net_raw=ep $(BINDIR)/$(NAME)
+
+$(UNIT_TEST_TARGET): $(UNIT_TEST_SRC) $(filter-out src/main.c,$(SRC))
+	mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(DEBUG_CFLAGS) -Isrc $^ -o $@ \
+		$(DEBUG_LDFLAGS) $(shell pkg-config --cflags --libs criterion) $(LIBS)
+
+test: $(UNIT_TEST_TARGET)
+	./$(UNIT_TEST_TARGET)

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,37 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2015 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "ubridge.h"
+#include "ubridge_options.h"
+
+int main(int argc, char **argv)
+{
+  ubridge_options_t opts = parse_cli_args(argc, argv);
+  run_ubridge(opts);
+
+  if (opts.mode == UBRIDGE_MODE_HYPERVISOR_TCP)
+    free(opts.tcp.ip);
+  return (EXIT_SUCCESS);
+}

--- a/src/parse.c
+++ b/src/parse.c
@@ -120,8 +120,7 @@ static bridge_t *add_bridge(bridge_t **head)
 {
    bridge_t *bridge;
 
-   if ((bridge = malloc(sizeof(*bridge))) != NULL) {
-      memset(bridge, 0, sizeof(*bridge));
+   if ((bridge = calloc(1, sizeof(*bridge))) != NULL) {
       bridge->next = *head;
       *head = bridge;
    }

--- a/src/ubridge.c
+++ b/src/ubridge.c
@@ -322,6 +322,7 @@ static void create_threads(bridge_t *bridge)
        s = pthread_create(&(bridge->destination_tid), NULL, &destination_nio_listener, bridge);
        if (s != 0)
          handle_error_en(s, "pthread_create");
+       bridge->running = TRUE;
        bridge = bridge->next;
     }
 }

--- a/src/ubridge.c
+++ b/src/ubridge.c
@@ -43,7 +43,6 @@ char *config_file = CONFIG_FILE;
 pthread_mutex_t global_lock = PTHREAD_MUTEX_INITIALIZER;
 bridge_t *bridge_list = NULL;
 int debug_level = 0;
-int hypervisor_mode = 0;
 
 /* Send callback for the delay line's release thread: forward a due packet out
  * the transmitting NIO and account for it. (When no delay filter is present,
@@ -340,8 +339,7 @@ void signal_gen_handler(int sig)
       case SIGTERM:
       case SIGINT:
          /* CTRL+C has been pressed */
-         if (hypervisor_mode)
-            hypervisor_stopsig();
+         hypervisor_stopsig();
          break;
          /* SIGHUP: configuration reload */
       case SIGHUP:
@@ -373,24 +371,13 @@ int iniparser_error_handler(const char *format, ...)
   return ret;
 }
 
-static void ubridge(char *hypervisor_ip_address, int hypervisor_tcp_port, char *hypervisor_socket_path)
+void run_ubridge(ubridge_options_t opts)
 {
-   if (hypervisor_mode) {
-       struct sigaction act;
+   printf("uBridge version %s running with %s\n", VERSION, pcap_lib_version());
 
-       memset(&act, 0, sizeof(act));
-       act.sa_handler = signal_gen_handler;
-       act.sa_flags = SA_RESTART;
-       sigaction(SIGHUP, &act, NULL);
-       sigaction(SIGTERM, &act, NULL);
-       sigaction(SIGINT, &act, NULL);
-       sigaction(SIGPIPE, &act, NULL);
+   debug_level = opts.debug_level;
 
-      run_hypervisor(hypervisor_ip_address, hypervisor_tcp_port, hypervisor_socket_path);
-      free_bridges(bridge_list);
-      free_iol_bridges(iol_bridge_list);
-   }
-   else {
+   if (opts.mode == UBRIDGE_MODE_CONFIG_FILE) {
       sigset_t sigset;
       int sig;
 
@@ -402,7 +389,7 @@ static void ubridge(char *hypervisor_ip_address, int hypervisor_tcp_port, char *
       pthread_sigmask(SIG_BLOCK, &sigset, NULL);
 
       while (1) {
-         if (!parse_config(config_file, &bridge_list))
+         if (!parse_config(opts.config.path, &bridge_list))
             break;
          create_threads(bridge_list);
          sigwait(&sigset, &sig);
@@ -412,105 +399,32 @@ static void ubridge(char *hypervisor_ip_address, int hypervisor_tcp_port, char *
          if (sig == SIGTERM || sig == SIGINT)
             break;
          printf("Reloading configuration\n");
-     }
+      }
    }
-}
+   else {
+      struct sigaction act;
 
-/* Display all network devices on this host */
-static void display_network_devices(void)
-{
-   char pcap_errbuf[PCAP_ERRBUF_SIZE];
-   pcap_if_t *device_list, *device;
-   int res;
+      memset(&act, 0, sizeof(act));
+      act.sa_handler = signal_gen_handler;
+      act.sa_flags = SA_RESTART;
+      sigaction(SIGHUP, &act, NULL);
+      sigaction(SIGTERM, &act, NULL);
+      sigaction(SIGINT, &act, NULL);
+      sigaction(SIGPIPE, &act, NULL);
 
-   printf("Network device list:\n\n");
+      switch (opts.mode) {
+        case UBRIDGE_MODE_HYPERVISOR_TCP:
+          run_hypervisor(opts.tcp.ip, opts.tcp.port, NULL);
+          break;
+        case UBRIDGE_MODE_HYPERVISOR_UNIX:
+          run_hypervisor(NULL, 0, opts.unix_socket.path);
+          break;
+        default:
+          fprintf(stderr, "Invalid hypervisor mode\n");
+          return;
+      }
 
-   res = pcap_findalldevs(&device_list, pcap_errbuf);
-
-   if (res < 0) {
-      fprintf(stderr, "PCAP: unable to find device list (%s)\n", pcap_errbuf);
-      return;
+      free_bridges(bridge_list);
+      free_iol_bridges(iol_bridge_list);
    }
-
-   for(device = device_list; device; device = device->next)
-      printf("  %s => %s\n", device->name, device->description ? device->description : "no description");
-   printf("\n");
-
-   pcap_freealldevs(device_list);
-}
-
-static void print_usage(const char *program_name)
-{
-  printf("Usage: %s [OPTION]\n"
-         "\n"
-         "Options:\n"
-         "  -h                           : Print this message and exit\n"
-         "  -f <file>                    : Specify a INI configuration file (default: %s)\n"
-         "  -H [<ip_address>:]<tcp_port> : Hypervisor mode over TCP (default bind: 127.0.0.1)\n"
-         "  -U <socket_path>             : Hypervisor mode over UNIX socket (recommended)\n"
-         "  -e                           : Display all available network devices and exit\n"
-         "  -d <level>                   : Debug level\n"
-         "  -v                           : Print version and exit\n",
-         program_name,
-         CONFIG_FILE);
-}
-
-int main(int argc, char **argv)
-{
-  int hypervisor_tcp_port = 0;
-  char *hypervisor_ip_address = NULL;
-  char *hypervisor_socket_path = NULL;
-  int opt;
-  char *index;
-  size_t len;
-
-  setvbuf(stdout, NULL, _IOLBF, 0);
-  setvbuf(stderr, NULL, _IOLBF, 0);
-
-  while ((opt = getopt(argc, argv, "hved:f:H:U:")) != -1) {
-    switch (opt) {
-      case 'H':
-        hypervisor_mode = 1;
-        index = strrchr(optarg, ':');
-        if (!index) {
-           hypervisor_tcp_port = atoi(optarg);
-        } else {
-           len = index - optarg;
-           hypervisor_ip_address = realloc(hypervisor_ip_address, len + 1);
-
-           if (!hypervisor_ip_address) {
-              fprintf(stderr, "Unable to set hypervisor IP address!\n");
-              exit(EXIT_FAILURE);
-           }
-           memcpy(hypervisor_ip_address, optarg, len);
-           hypervisor_ip_address[len] = '\0';
-           hypervisor_tcp_port = atoi(index + 1);
-        }
-        break;
-      case 'U':
-        hypervisor_mode = 1;
-        hypervisor_socket_path = optarg;
-        break;
-	  case 'v':
-	    printf("%s version %s\n", NAME, VERSION);
-	    exit(EXIT_SUCCESS);
-	  case 'h':
-	    print_usage(argv[0]);
-	    exit(EXIT_SUCCESS);
-	  case 'e':
-	    display_network_devices();
-	    exit(EXIT_SUCCESS);
-	  case 'd':
-        debug_level = atoi(optarg);
-        break;
-	  case 'f':
-        config_file = optarg;
-        break;
-      default:
-        exit(EXIT_FAILURE);
-	}
-  }
-  printf("uBridge version %s running with %s\n", VERSION, pcap_lib_version());
-  ubridge(hypervisor_ip_address, hypervisor_tcp_port, hypervisor_socket_path);
-  return (EXIT_SUCCESS);
 }

--- a/src/ubridge.h
+++ b/src/ubridge.h
@@ -29,6 +29,7 @@
 
 #include "nio.h"
 #include "packet_filter.h"
+#include "ubridge_options.h"
 
 #define NAME          "ubridge"
 #define VERSION       "1.2.2"
@@ -71,6 +72,7 @@ extern pthread_mutex_t global_lock;
 extern int debug_level;
 
 void ubridge_reset();
+void run_ubridge(ubridge_options_t config);
 void *source_nio_listener(void *data);
 void *destination_nio_listener(void *data);
 

--- a/src/ubridge_options.c
+++ b/src/ubridge_options.c
@@ -1,0 +1,141 @@
+/*
+ *   This file is part of ubridge, a program to bridge network interfaces
+ *   to UDP tunnels.
+ *
+ *   Copyright (C) 2015 GNS3 Technologies Inc.
+ *
+ *   ubridge is free software: you can redistribute it and/or modify it
+ *   under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   ubridge is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "ubridge.h"
+
+static void display_network_devices(void)
+{
+  char       pcap_errbuf[PCAP_ERRBUF_SIZE];
+  pcap_if_t *device_list, *device;
+  int        res;
+
+  printf("Network device list:\n\n");
+  res = pcap_findalldevs(&device_list, pcap_errbuf);
+  if (res < 0) {
+    fprintf(stderr, "PCAP: unable to find device list (%s)\n", pcap_errbuf);
+    return;
+  }
+
+  for (device = device_list; device; device = device->next)
+    printf("  %s => %s\n", device->name,
+           device->description ? device->description : "no description");
+  printf("\n");
+
+  pcap_freealldevs(device_list);
+}
+
+static void print_usage(const char *program_name)
+{
+  printf("Usage: %s [OPTION]\n"
+         "\n"
+         "Options:\n"
+         "  -h                           : Print this message and exit\n"
+         "  -f <file>                    : Specify a INI configuration file "
+         "(default: %s)\n"
+         "  -H [<ip_address>:]<tcp_port> : Hypervisor mode over TCP (default "
+         "bind: 127.0.0.1)\n"
+         "  -U <socket_path>             : Hypervisor mode over UNIX socket "
+         "(recommended)\n"
+         "  -e                           : Display all available network "
+         "devices and exit\n"
+         "  -d <level>                   : Debug level\n"
+         "  -v                           : Print version and exit\n",
+         program_name, CONFIG_FILE);
+}
+
+ubridge_options_t parse_cli_args(int argc, char **argv)
+{
+  int               opt;
+  char             *index;
+  bool              mode_selected = false;
+  ubridge_options_t opts = {
+    .debug_level = 0,
+    .config.path = CONFIG_FILE,
+    .mode = UBRIDGE_MODE_CONFIG_FILE
+  };
+
+  setvbuf(stdout, NULL, _IOLBF, 0);
+  setvbuf(stderr, NULL, _IOLBF, 0);
+
+  while ((opt = getopt(argc, argv, "hved:f:H:U:")) != -1) {
+    switch (opt) {
+    case 'H':
+      if (mode_selected)
+        goto err;
+      mode_selected = true;
+      opts.mode = UBRIDGE_MODE_HYPERVISOR_TCP;
+      index = strrchr(optarg, ':');
+      if (!index) {
+        opts.tcp.port = atoi(optarg);
+        opts.tcp.ip = NULL;
+      } else {
+        opts.tcp.ip = strndup(optarg, index - optarg);
+        if (!opts.tcp.ip) {
+          fprintf(stderr, "Unable to set hypervisor IP address!\n");
+          exit(EXIT_FAILURE);
+        }
+        opts.tcp.port = atoi(index + 1);
+      }
+      break;
+    case 'U':
+      if (mode_selected)
+        goto err;
+      mode_selected = true;
+      opts.mode = UBRIDGE_MODE_HYPERVISOR_UNIX;
+      opts.unix_socket.path = optarg;
+      break;
+    case 'v':
+      printf("%s version %s\n", NAME, VERSION);
+      exit(EXIT_SUCCESS);
+    case 'h':
+      print_usage(argv[0]);
+      exit(EXIT_SUCCESS);
+    case 'e':
+      display_network_devices();
+      exit(EXIT_SUCCESS);
+    case 'd':
+      opts.debug_level = atoi(optarg);
+      break;
+    case 'f':
+      if (mode_selected)
+        goto err;
+      mode_selected = true;
+      opts.mode = UBRIDGE_MODE_CONFIG_FILE;
+      opts.config.path = optarg;
+      break;
+    default:
+      exit(EXIT_FAILURE);
+    }
+  }
+  return opts;
+
+err:
+  fprintf(stderr, "Only one of -f, -H, or -U may be specified\n");
+  if (opts.mode == UBRIDGE_MODE_HYPERVISOR_TCP)
+    free(opts.tcp.ip);
+  exit(EXIT_FAILURE);
+}

--- a/src/ubridge_options.h
+++ b/src/ubridge_options.h
@@ -1,0 +1,31 @@
+#ifndef UBRIDGE_OPTS_H
+#define UBRIDGE_OPTS_H
+
+typedef enum {
+  UBRIDGE_MODE_CONFIG_FILE,
+  UBRIDGE_MODE_HYPERVISOR_TCP,
+  UBRIDGE_MODE_HYPERVISOR_UNIX,
+} ubridge_mode_t;
+
+typedef struct {
+  int            debug_level;
+  ubridge_mode_t mode;
+
+  union {
+    struct {
+      char *path;
+    } config;
+
+    struct {
+      char *ip;
+      int   port;
+    } tcp;
+
+    struct {
+      char *path;
+    } unix_socket;
+  };
+} ubridge_options_t;
+
+ubridge_options_t parse_cli_args(int argc, char **argv);
+#endif

--- a/tests/unit/fixtures/test.ini
+++ b/tests/unit/fixtures/test.ini
@@ -1,0 +1,4 @@
+[bridge0]
+source_udp = 0:127.0.0.1:9
+destination_udp = 0:127.0.0.1:9
+pcap_file = tests/unit/fixtures/reload.pcap

--- a/tests/unit/test_memory.c
+++ b/tests/unit/test_memory.c
@@ -1,0 +1,68 @@
+#include <criterion/criterion.h>
+#include <glob.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "ubridge.h"
+
+static int wait_for_file(const char *path)
+{
+  for (int i = 0; i < 200; i++) {
+    if (access(path, F_OK) == 0)
+      return TRUE;
+    usleep(10000);
+  }
+  return FALSE;
+}
+
+static size_t thread_count(pid_t pid)
+{
+  char   pattern[64];
+  glob_t tasks = {0};
+
+  snprintf(pattern, sizeof(pattern), "/proc/%ld/task/*", (long)pid);
+  glob(pattern, GLOB_NOSORT, NULL, &tasks);
+  size_t count = tasks.gl_pathc;
+  globfree(&tasks);
+  return count;
+}
+
+Test(mem, config_reload, .timeout = 5)
+{
+  const char       *capture_path = "tests/unit/fixtures/reload.pcap";
+  int               status;
+  ubridge_options_t opts = {
+    .mode = UBRIDGE_MODE_CONFIG_FILE,
+    .config.path = "tests/unit/fixtures/test.ini",
+  };
+  unlink(capture_path);
+
+  pid_t pid = fork();
+  cr_assert_neq(pid, -1);
+
+  if (pid == 0) {
+    run_ubridge(opts);
+    _exit(EXIT_SUCCESS);
+  }
+
+  cr_assert(wait_for_file(capture_path));
+  usleep(250000); // 250ms
+  cr_assert_eq(thread_count(pid), 3);
+  cr_assert_eq(unlink(capture_path), 0);
+  cr_assert_eq(kill(pid, SIGHUP), 0);
+
+  cr_assert(wait_for_file(capture_path));
+  usleep(250000); // 250ms
+  cr_assert_eq(thread_count(pid), 3,
+               "reload left old bridge listener threads running");
+  cr_assert_eq(kill(pid, SIGTERM), 0);
+
+  cr_assert_eq(waitpid(pid, &status, 0), pid);
+  unlink(capture_path);
+
+  cr_assert(WIFEXITED(status));
+  cr_assert_eq(WEXITSTATUS(status), EXIT_SUCCESS);
+}


### PR DESCRIPTION
As I read the sources I more and more see some design flaws that prevent unit-testing a lot. Thus this is just a start (I have some good plans for the future we can discuss) and hope you will welcome those changes and point out if you don't like something.

While I was refactoring I also found out a serious bug, especially can be seen on configuration reloads - fixed in this commit c805ef